### PR TITLE
Pre-install kubernetes and openshift plugins in Jenkins image

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -42,7 +42,8 @@ COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin
 ADD ./contrib/s2i /usr/libexec/s2i
 
-RUN /usr/local/bin/fix-permissions /opt/openshift && \
+RUN /usr/local/bin/plugins.sh /opt/openshift/base-plugins.txt && \
+    /usr/local/bin/fix-permissions /opt/openshift && \
     /usr/local/bin/fix-permissions /var/lib/jenkins
 
 VOLUME ["/var/lib/jenkins"]

--- a/1/Dockerfile.rhel7
+++ b/1/Dockerfile.rhel7
@@ -33,7 +33,7 @@ LABEL BZComponent="openshift-jenkins-docker" \
 # 8080 for main web interface, 50000 for slave agents
 EXPOSE 8080 50000
 
-RUN yum install -y gettext git tar zip unzip java-1.7.0-openjdk jenkins-1.609.1 && \
+RUN yum install -y gettext git tar zip unzip java-1.7.0-openjdk jenkins-1.609.1 jenkins-plugin-kubernetes jenkins-plugin-openshift-pipeline && \
     yum install -y --disablerepo="epel" --setopt=tsflags=nodocs nss_wrapper && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,0 +1,3 @@
+kubernetes:0.4.1
+durable-task:1.6
+credentials:1.24


### PR DESCRIPTION
Do not merge this PR until we can see in Jenkins that the two packages are installed during the build.

For RHEL7 this will pull the two RPM's @tdawson created for us.
For Centos7 we just use the `plugins.sh` mechanism to install the plugins during the build.

We should keep the plugin versions in sync between rhel7 and centos7. (they will start to diverge at some point, so we need to add some tests to exercise them for both base images)