### PR TITLE
add plugin to centos image; apply plugin rename to config files; replace sample job with plugin

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -42,7 +42,8 @@ COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin
 ADD ./contrib/s2i /usr/libexec/s2i
 
-RUN /usr/local/bin/fix-permissions /opt/openshift && \
+RUN /usr/local/bin/plugins.sh /opt/openshift/base-plugins.txt && \
+    /usr/local/bin/fix-permissions /opt/openshift && \
     /usr/local/bin/fix-permissions /var/lib/jenkins
 
 VOLUME ["/var/lib/jenkins"]

--- a/1/Dockerfile.rhel7
+++ b/1/Dockerfile.rhel7
@@ -33,7 +33,7 @@ LABEL BZComponent="openshift-jenkins-docker" \
 # 8080 for main web interface, 50000 for slave agents
 EXPOSE 8080 50000
 
-RUN yum install -y gettext git tar zip unzip java-1.7.0-openjdk jenkins-1.609.1 && \
+RUN yum install -y gettext git tar zip unzip java-1.7.0-openjdk jenkins-1.609.1 jenkins-plugin-kubernetes jenkins-plugin-openshift-pipeline && \
     yum install -y --disablerepo="epel" --setopt=tsflags=nodocs nss_wrapper && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,0 +1,4 @@
+kubernetes:0.4.1
+durable-task:1.6
+credentials:1.24
+openshift-pipeline:1.0.1

--- a/1/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
+++ b/1/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
@@ -3,61 +3,6 @@
   <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
-  <properties>
-    <hudson.model.ParametersDefinitionProperty>
-      <parameterDefinitions>
-
-        <hudson.model.StringParameterDefinition>
-          <name>OPENSHIFT_API_URL</name>
-          <description>URL of the OpenShift api endpoint.</description>
-          <defaultValue>https://openshift.default.svc.cluster.local</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-        <hudson.model.TextParameterDefinition>
-          <name>AUTH_TOKEN</name>
-          <description>Authentication token of an account/serviceaccount for accessing the project to run builds and tag images.  If you are running Jenkins in the same OpenShift deployment that it is communicating with and you have granted appropriate roles to the service account for the pod (normally "default"), you can leave this blank.</description>
-          <defaultValue></defaultValue>
-        </hudson.model.TextParameterDefinition>
-        
-        <hudson.model.StringParameterDefinition>
-          <name>PROJECT</name>
-          <description>The OpenShift project this job will access</description>
-          <defaultValue>test</defaultValue>
-        </hudson.model.StringParameterDefinition>
-        
-        <hudson.model.StringParameterDefinition>
-          <name>BUILD_CONFIG</name>
-          <description>The name of the BuildConfig to trigger</description>
-          <defaultValue>frontend</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-        <hudson.model.StringParameterDefinition>
-          <name>TEST_IMAGE_TAG</name>
-          <description>The image:tag produced by the BuildConfig which will be tagged for promotion if the tests are successful.</description>
-          <defaultValue>origin-nodejs-sample:latest</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-        <hudson.model.StringParameterDefinition>
-          <name>PRODUCTION_IMAGE_TAG</name>
-          <description>The tag to apply to the tested image to trigger a production deployment.</description>
-          <defaultValue>origin-nodejs-sample:prod</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-        <hudson.model.StringParameterDefinition>
-          <name>SERVICE</name>
-          <description>The service to test after build completion</description>
-          <defaultValue>frontend</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-        <hudson.model.StringParameterDefinition>
-          <name>DEPLOYMENT_CONFIG</name>
-          <description>The name of the DeploymentConfig that deploys the output of the BuildConfig</description>
-          <defaultValue>frontend</defaultValue>
-        </hudson.model.StringParameterDefinition>
-
-      </parameterDefinitions>
-    </hudson.model.ParametersDefinitionProperty>
-  </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
@@ -66,126 +11,77 @@
   <triggers/>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.tasks.Shell>
-      <command>
-if [ -z &quot;$AUTH_TOKEN&quot; ]; then
-  AUTH_TOKEN=`cat /var/run/secrets/kubernetes.io/serviceaccount/token`
-fi
 
-if [ -e /run/secrets/kubernetes.io/serviceaccount/ca.crt ]; then
-  alias oc=&quot;oc -n $PROJECT --token=$AUTH_TOKEN --server=$OPENSHIFT_API_URL --certificate-authority=/run/secrets/kubernetes.io/serviceaccount/ca.crt &quot;
-else 
-  alias oc=&quot;oc -n $PROJECT --token=$AUTH_TOKEN --server=$OPENSHIFT_API_URL --insecure-skip-tls-verify &quot;
-fi
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>0</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+    
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>0</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
-TEST_ENDPOINT=`oc get service ${SERVICE} -t &apos;{{.spec.clusterIP}}{{&quot;:&quot;}}{{ $a:= index .spec.ports 0 }}{{$a.port}}&apos;`
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <bldCfg>frontend</bldCfg>
+      <namespace>test</namespace>
+      <authToken></authToken>
+      <followLog>true</followLog>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
+    
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>1</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
-rm old_rc_id || true
-echo "none" &gt; old_rc_id
-oc get rc -t &apos;{{ range .items }}{{.spec.selector.deploymentconfig}}{{&quot; &quot;}}{{.metadata.name}}{{&quot;\n&quot;}}{{end}}&apos; | grep -e &quot;^$DEPLOYMENT_CONFIG &quot; | awk &apos;{print $2}&apos; | while read -r test_rc_id; do
-  echo &quot;Scaling down old deployment $test_rc_id&quot;
-  oc scale --replicas=0 rc $test_rc_id
-  echo $test_rc_id &gt;&gt; old_rc_id
-done
-old_rc_id=`cat old_rc_id | awk -F - &apos;{print $NF&quot; &quot;$0}&apos; | sort -n | awk &apos;{print $2}&apos; | tail -n 1`
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>1</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>1</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
-# wait for old pods to be torn down
-# TODO should poll instead.
-sleep 5
+     <com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <svcName>frontend</svcName>
+      <namespace>test</namespace>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
 
-echo &quot;Triggering new application build and deployment&quot;
-BUILD_ID=`oc start-build ${BUILD_CONFIG}`
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <namespace>test</namespace>
+      <testTag>origin-nodejs-sample:latest</testTag>
+      <prodTag>origin-nodejs-sample:prod</prodTag>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
+    
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+      <apiURL>https://openshift.default.svc.cluster.local</apiURL>
+      <depCfg>frontend-prod</depCfg>
+      <namespace>test</namespace>
+      <replicaCount>1</replicaCount>
+      <authToken></authToken>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
-# stream the logs for the build that just started
-rc=1
-count=0
-attempts=3
-set +e
-while [ $rc -ne 0 -a $count -lt $attempts ]; do
-  oc build-logs $BUILD_ID
-  rc=$?
-  count=$(($count+1))
-done
-set -e
-
-echo &quot;Checking build result status&quot;
-rc=1
-count=0
-attempts=100
-while [ $rc -ne 0 -a $count -lt $attempts ]; do
-  status=`oc get build ${BUILD_ID} -t &apos;{{.status.phase}}&apos;`
-  if [[ $status == &quot;Failed&quot; || $status == &quot;Error&quot; || $status == &quot;Canceled&quot; ]]; then
-    echo &quot;Fail: Build completed with unsuccessful status: ${status}&quot;
-    exit 1
-  fi
-
-  if [ $status == &quot;Complete&quot; ]; then
-    echo &quot;Build completed successfully, will test deployment next&quot;
-    rc=0
-  else 
-    count=$(($count+1))
-    echo &quot;Attempt $count/$attempts&quot;
-    sleep 5
-  fi
-done
-
-if [ $rc -ne 0 ]; then
-    echo &quot;Fail: Build did not complete in a reasonable period of time&quot;
-    exit 1
-fi
-
-
-# scale up the test deployment
-# if this gets scaled up before the new deployment occurs from the build,
-# bad things happen...need to make sure a new deployment has occurred first.
-count=0
-attempts=20
-new_rc_id=$old_rc_id
-while [ $new_rc_id == $old_rc_id -a $count -lt $attempts ]; do
-  rm new_rc_id || true
-  oc get rc -t &apos;{{ range .items }}{{.spec.selector.deploymentconfig}}{{&quot; &quot;}}{{.metadata.name}}{{&quot;\n&quot;}}{{end}}&apos; | grep -e &quot;^$DEPLOYMENT_CONFIG &quot; | awk &apos;{print $2}&apos; | while read -r test_rc_id; do
-    echo $test_rc_id &gt;&gt; new_rc_id
-  done
-  new_rc_id=`cat new_rc_id | awk -F - &apos;{print $NF&quot; &quot;$0}&apos; | sort -n | awk &apos;{print $2}&apos; | tail -n 1`
-  count=$(($count+1))
-  sleep 1
-done
-if [ $count -eq $attempts ]; then
-  echo "Failure: Never found new deployment"
-  exit 1
-fi
-
-test_rc_id=`cat new_rc_id | awk -F - &apos;{print $NF&quot; &quot;$0}&apos; | sort -n | awk &apos;{print $2}&apos; | tail -n 1`
-echo &quot;Scaling up new deployment $test_rc_id&quot;
-oc scale --replicas=1 rc $test_rc_id
-
-echo &quot;Checking for successful test deployment at $TEST_ENDPOINT&quot;
-set +e
-rc=1
-count=0
-attempts=100
-while [ $rc -ne 0 -a $count -lt $attempts ]; do
-  if curl -s --connect-timeout 2 $TEST_ENDPOINT &gt;&amp; /dev/null; then
-    rc=0
-    break
-  fi
-  count=$(($count+1))
-  echo &quot;Attempt $count/$attempts&quot;
-  sleep 5
-done
-set -e
-
-if [ $rc -ne 0 ]; then
-    echo &quot;Failed to access test deployment, aborting roll out.&quot;
-    exit 1
-fi
-
-
-# Tag the image into production
-echo &quot;Test deployment succeeded, rolling out to production...&quot;
-oc tag $TEST_IMAGE_TAG $PRODUCTION_IMAGE_TAG
-      </command>
-    </hudson.tasks.Shell>
   </builders>
   <publishers/>
   <buildWrappers/>

--- a/README.md
+++ b/README.md
@@ -107,6 +107,19 @@ github:1.11.3
 
 After this, just run `docker build -t my_jenkins_image -f Dockerfile`.
 
+Furthermore,  there are now 2 plugins of note included in this Jenkins Docker image that specifically facilitate the creation
+of CI/CD jobs and workflows for [OpenShift v3](https://github.com/openshift/origin):
+
+* **OpenShift Pipeline plugin**
+
+  See [the following](https://github.com/openshift/jenkins-plugin), as well an example use of the plugin's capabilities with the [OpenShift Sample Job](https://github.com/openshift/jenkins/tree/master/1/contrib/openshift/configuration/jobs/OpenShift%20Sample)
+  included in this image.
+
+* **Kubernetes plugin**
+
+  See [the following](https://github.com/jenkinsci/kubernetes-plugin), as well as the examples for constructing Jenkins [masters](https://github.com/openshift/jenkins/tree/master/examples/master) and
+  [slaves](https://github.com/openshift/jenkins/tree/master/examples/slave) that interact with [OpenShift v3](https://github.com/openshift/origin)
+
 Usage
 ---------------------------------
 

--- a/examples/master/configuration/jobs/sample-app-build/config.xml
+++ b/examples/master/configuration/jobs/sample-app-build/config.xml
@@ -27,20 +27,20 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
 
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftBuilder>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <bldCfg>sample-app</bldCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftBuilder>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
 
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>sample-app</depCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
   </builders>
   <publishers/>

--- a/examples/master/configuration/jobs/sample-app-deploy/config.xml
+++ b/examples/master/configuration/jobs/sample-app-deploy/config.xml
@@ -22,36 +22,36 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
 
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
 
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftDeployer>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftDeployer>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
     
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>ci</nameSpace>
+      <namespace>ci</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftDeploymentVerifier>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
   </builders>
   <publishers/>

--- a/examples/master/configuration/jobs/sample-app-stage/config.xml
+++ b/examples/master/configuration/jobs/sample-app-stage/config.xml
@@ -18,11 +18,11 @@
       <stageName>Deploy</stageName>
     </se.diabol.jenkins.pipeline.PipelineProperty>
   </properties>
-  <scm class="com.openshift.openshiftjenkinsbuildutils.OpenShiftImageStreams" plugin="openshift-jenkins-buildutils@1.0-SNAPSHOT">
+  <scm class="com.openshift.jenkins.plugins.pipeline.OpenShiftImageStreams" plugin="openshift-jenkins-buildutils@1.0-SNAPSHOT">
     <imageStreamName>sample-app</imageStreamName>
     <tag>latest</tag>
     <apiURL>https://openshift.default.svc.cluster.local</apiURL>
-    <nameSpace>ci</nameSpace>
+    <namespace>ci</namespace>
     <authToken></authToken>
   </scm>
   <assignedNode>master</assignedNode>
@@ -38,20 +38,20 @@
   </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler plugin="openshift-jenkins-buildutils@1.0-SNAPSHOT">
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler plugin="openshift-pipeline@1.0">
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>stage</nameSpace>
+      <namespace>stage</namespace>
       <replicaCount>0</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler>
-    <com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler plugin="openshift-jenkins-buildutils@1.0-SNAPSHOT">
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler plugin="openshift-pipeline@1.0">
       <apiURL>https://openshift.default.svc.cluster.local</apiURL>
       <depCfg>frontend</depCfg>
-      <nameSpace>stage</nameSpace>
+      <namespace>stage</namespace>
       <replicaCount>1</replicaCount>
       <authToken></authToken>
-    </com.openshift.openshiftjenkinsbuildutils.OpenShiftScaler>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
   </builders>
   <publishers>
     <hudson.tasks.Mailer plugin="mailer@1.11">


### PR DESCRIPTION
@mfojtik @bparees this is similar to PR https://github.com/openshift/jenkins/pull/46 but with some twists, but including the do not merge status for now.

Specifically:
1) I've renamed plugin configuration for @mfojtik 's master/slave examples 
2) I've add the openshift pipeline plugin to the base plugin list @mfojtik added with the above pull
3) I've converted the sample job to leverage a series of plugin steps vs. the shell script

In a momentary divergence from @mfojtik 's PR, I refrained the rhel image / rpm install changes for now.  I'll add them when then show up and I've had a chance to try them.