### PR TITLE
upgrade to 1.0.3 of plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
 kubernetes:0.4.1
 durable-task:1.6
 credentials:1.24
-openshift-pipeline:1.0.1
+openshift-pipeline:1.0.3


### PR DESCRIPTION
@bparees moving the image to include the version of the plugin QE should run against for centos.  The 1.0.3 RPM for rhel has already been built.

(I was originally driving this change in the master/slave PR https://github.com/openshift/jenkins/pull/52 but am separating it out so we can get test going while we sort out the master slave stuff; the 1.0.3 changes are either generic fixes or the build parameter override feature, nothing specific to master/slave)