### PR TITLE
bump to 104 of the plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,1 +1,1 @@
-openshift-pipeline:1.0.3
+openshift-pipeline:1.0.4


### PR DESCRIPTION
@bparees PTAL - fyi, we need to move to his version to address bugs seen by both upstream and QA since QA has started.  I've already pinged @tdawson about building the rpm for the plugin for the rhel image.  The centos image pulls directly from the update center, which is now hosting version 1.0.4.