### PR TITLE
Add durable-task and pin the credentials plugin

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -43,6 +43,7 @@ COPY ./contrib/jenkins /usr/local/bin
 ADD ./contrib/s2i /usr/libexec/s2i
 
 RUN /usr/local/bin/plugins.sh /opt/openshift/base-plugins.txt && \
+    touch /opt/openshift/plugins/credentials.jpi.pinned && \
     chown -R 1001:0 /opt/openshift && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     /usr/local/bin/fix-permissions /var/lib/jenkins

--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,2 +1,4 @@
 openshift-pipeline:1.0.7
+durable-task:1.6
 kubernetes:0.4.1
+credentials:1.24


### PR DESCRIPTION
@bparees @tdawson I found couple issues with the kubernetes plugin. I know that the plugin is available in brew and the test proves that it could be installed just fine, but:

1) The plugin requires "durable-task" plugin as an dependency. If this plugin is not installed, Jenkins will fail to initialize the kubernetes plugin with pretty ugly error. So we need to package that plugin as well and make it as an dependency for kubernetes plugin (and by doing that, we should bump the kubernetes plugin version ;-))

2) The kubernetes plugin require pretty recent version of the "credentials" plugin, which is a real problem. This plugin is currently **bundled** in the official Jenkins RPM. So it cannot be updated using "rpm". Kubernetes plugin needs it in order to be able to read the Service Account token....

There we have two possible options to fix this (maybe there are more):

a) We tell Jenkins maintainers in RHEL7 to bump the credentials plugin version and do z-stream release (i'm 99% sure they will refuse)

b) We can add the updated version of the plugin to Jenkins image dist-git and create "credentials.jpi.pinned" file in Dockerfile.rhel7. Similar to what we do for centos7. This way, Jenkins will get latest plugin and it will ignore the bundled one.

Good news is that we are probably OK with centos7 image where we can just install the plugin from official Jenkins mirror and pin it in Dockerfile (which is what this PR is about ;-) 