### PR TITLE
bump to v109 of openshift pipeline plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.8
+openshift-pipeline:1.0.9
 durable-task:1.6
 kubernetes:0.5
 credentials:1.24


### PR DESCRIPTION
@bparees @mfojtik FYI / PTAL

I've created v1.0.9 of the openshift pipeline plug-in up at then jenkins update center.

The most important change, which lead to my cutting a new version now so we could include in official releases if we deem appropriate, was the issue I emailed about last week with getting the image's mounted cert into the java trust store used by the openshift-restclient-java component.  As far as SSL/TLS goes, we were basically always in "skip TLS" mode (well, skip TLS plus a couple of minor verifications I could do at the plugin level).  With this version, the cert is now getting added into a java x509 trust store maintained by the plugin and the communication with the server is getting fully validated from a TLS perspective (I was able to validate both good certs pass and bad certs were denied).  I'll be circling back and submitting a pull to update openshift-restclient-java later this week.

I also added the ability to import a new cert, and explicitly choose to run in "skip tls" mode, but took a minimal approach and only surfaced it through ENV vars.  I want to circle back later and see if I can make the credentials plugin work with openshift-restclient-java when I have time to focus on it.

Other changes in v109:
- the new messages
- pulling the api url and project name defaults from the image env vars vs. the prior hard coded defaults
- not using "frontend", etc. as defaults for build configs, deployement configs
- fixed a couple of minor bugs/exceptions reported by users