### PR TITLE
move to 1.0.11 of openshift pipeline plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.10
+openshift-pipeline:1.0.11
 durable-task:1.6
 kubernetes:0.5
 credentials:1.24


### PR DESCRIPTION
@bparees PTAL

This version has 2 bugzilla fixes from QE testing of my 2 plugin cards this sprint, as well as an upstream ask around exiting failed builds more expediently, followed by an NPE fix that @sspeiche found.