### PR TITLE
go to workflow-cps 2.2 for UI development

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -13,7 +13,8 @@ workflow-cps-global-lib:2.0
 workflow-job:2.0
 pipeline-build-step:2.0
 workflow-multibranch:2.0
-workflow-cps:2.0
+# went to 2.2 here for https://github.com/fabric8io/openshift-jenkins-sync-plugin/issues/57
+workflow-cps:2.2
 workflow-scm-step:2.0
 pipeline-stage-step:2.0
 workflow-basic-steps:2.0


### PR DESCRIPTION
@mfojtik ptal / merge

@bparees @jwforres FYI - the upgrade to 2.2 is motivated by https://github.com/fabric8io/openshift-jenkins-sync-plugin/issues/57

My regression testing of the new openshift pipeline DSL held up with v2.2 of workflow-cps