### PR TITLE
move to v1.0.21 of pipeline plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.20
+openshift-pipeline:1.0.21
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 durable-task:1.10


### PR DESCRIPTION
@bparees ptal

i was able to verify that the associated rhel rpm for this version is picked up during rhel build