### PR TITLE
add read permission to viewers

### DIFF
--- a/1/contrib/openshift/configuration/config.xml.tpl
+++ b/1/contrib/openshift/configuration/config.xml.tpl
@@ -6,11 +6,11 @@
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
   <authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">
-    <permission>hudson.model.Computer.Configure:admin</permission>
     <permission>hudson.model.Computer.Configure:system_builder</permission>
+    <permission>hudson.model.Hudson.Administer:system_builder</permission>
+    <permission>hudson.model.Computer.Configure:admin</permission>
     <permission>hudson.model.Computer.Delete:admin</permission>
     <permission>hudson.model.Hudson.Administer:admin</permission>
-    <permission>hudson.model.Hudson.Administer:system_builder</permission>
     <permission>hudson.model.Hudson.Read:admin</permission>
     <permission>hudson.model.Hudson.Read:system_builder</permission>
     <permission>hudson.model.Item.Build:admin</permission>
@@ -25,6 +25,8 @@
     <permission>hudson.model.View.Create:admin</permission>
     <permission>hudson.model.View.Delete:admin</permission>
     <permission>hudson.scm.SCM.Tag:admin</permission>
+    <permission>hudson.model.Hudson.Read:view</permission>
+    <permission>hudson.model.Item.Read:view</permission>
   </authorizationStrategy>
   <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
     <disableSignup>true</disableSignup>


### PR DESCRIPTION
Adds view permission for the user or groups named "view".

@gabemontero there's no distinction between users and subjects.  This is going to create shadowing risks.  You should consider what you're doing.