### PR TITLE
jenkins image: fix permissions fix on rhel build

### DIFF
--- a/1/Dockerfile.rhel7
+++ b/1/Dockerfile.rhel7
@@ -55,6 +55,8 @@ RUN mkdir -p /opt/openshift/plugins && \
     touch /opt/openshift/plugins/script-security.jpi.pinned && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     chown -R 1001:0 /opt/openshift && \
+    # the prior chown doesn't traverse the /opt/openshift/plugins links .. this one will assist fix-permission/assemble for extension builds like master/slave
+    chown 1001:0 /usr/lib64/jenkins/*hpi && \ 
     /usr/local/bin/fix-permissions /var/lib/jenkins
 
 VOLUME ["/var/lib/jenkins"]


### PR DESCRIPTION
Bug 1365767
Bugzilla link https://bugzilla.redhat.com/show_bug.cgi?id=1365767
Detailed explanation
The chown in Dockerfile.rhel7 did not traverse the links and update
/usr/lib64/jenkins/*hpi

@bparees PTAL