### PR TITLE
show download error if any

### DIFF
--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -31,7 +31,7 @@ if [[ $# -gt 1 ]]; then
   fi
 
   echo "Downloading ${JENKINS_URL}/jnlpJars/remoting.jar ..."
-  curl -s ${JENKINS_URL}/jnlpJars/remoting.jar -o ${JAR}
+  curl -sS ${JENKINS_URL}/jnlpJars/remoting.jar -o ${JAR}
 
   # if -tunnel is not provided try env vars
   if [[ "$@" != *"-tunnel "* ]]; then


### PR DESCRIPTION
When launching slave it is likely to hit errors like non-trusted jenkins server certificate.
Without the `-S` option, curl exits with some status but no indication as to
what the problem actually is. `-S` option only tells curl to print things when
an error is hit. Not output will be present (as before) when things go smoothly.

btw, how do I take care of bad certificate? Any way I can setup server cert
so it is accepted without modifying Dockerfile?