### PR TITLE
go to v0.8 of login plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.31
-openshift-login:0.7
+openshift-login:0.8
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.31
-openshift-login:0.7
+openshift-login:0.8
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
v0.7 somehow missed a previous fix around inadvertent defaulting; also, 1 more small tweak in the logging was needed to clearly diagnose the issue in @csrwng 's env

with both changes, we were able to a) successfully *NOT* default to oauth, b) confirm a config/permissions issue existed in @csrwng 's env

@bparees fyi