### PR TITLE
bump login to v0.9

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.32
-openshift-login:0.8
+openshift-login:0.9
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.32
-openshift-login:0.8
+openshift-login:0.9
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
pulls in the fix for https://github.com/openshift/jenkins-openshift-login-plugin/issues/5

@bparees @jim-minter FYI 

@tdawson let's wait for @jim-minter to confirm this fix works for him before worrying
about the rpm / image respin.