### PR TITLE
update sample now that sample ICT is false; bump pipeline plugin

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.32
+openshift-pipeline:1.0.33
 openshift-login:0.9
 
 

--- a/1/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
+++ b/1/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
@@ -25,51 +25,53 @@
       <bldCfg>frontend</bldCfg>
       <namespace></namespace>
       <authToken></authToken>
-      <checkForTriggeredDeployments>true</checkForTriggeredDeployments>
+      <checkForTriggeredDeployments>false</checkForTriggeredDeployments>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
 
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
       <apiURL></apiURL>
-      <depCfg>frontend</depCfg>
       <namespace></namespace>
-      <replicaCount>0</replicaCount>
       <authToken></authToken>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
-      <apiURL></apiURL>
+      <verbose>false</verbose>
+      <waitTime></waitTime>
+      <waitUnit>sec</waitUnit>
       <depCfg>frontend</depCfg>
-      <namespace></namespace>
-      <replicaCount>1</replicaCount>
-      <authToken></authToken>
-      <verifyReplicaCount>true</verifyReplicaCount>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
     
     <com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
       <apiURL></apiURL>
-      <svcName>frontend</svcName>
       <namespace></namespace>
       <authToken></authToken>
+      <verbose>false</verbose>
+      <svcName>frontend</svcName>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
-
+    
     <com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
       <apiURL></apiURL>
       <namespace></namespace>
+      <authToken></authToken>
+      <verbose>false</verbose>
       <testTag>latest</testTag>
       <prodTag>prod</prodTag>
       <testStream>origin-nodejs-sample</testStream>
       <prodStream>origin-nodejs-sample</prodStream>
-      <authToken></authToken>
+      <destinationNamespace></destinationNamespace>
+      <destinationAuthToken></destinationAuthToken>
+      <alias>false</alias>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
 
     <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL></apiURL>
-      <depCfg>frontend-prod</depCfg>
       <namespace></namespace>
-      <replicaCount>0</replicaCount>
       <authToken></authToken>
+      <verbose>false</verbose>
+      <waitTime></waitTime>
+      <waitUnit>milli</waitUnit>
+      <depCfg>frontend-prod</depCfg>
+      <replicaCount>1</replicaCount>
+      <verifyReplicaCount>false</verifyReplicaCount>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-
+    
   </builders>
   <publishers/>
   <buildWrappers/>

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.32
+openshift-pipeline:1.0.33
 openshift-login:0.9
 
 

--- a/2/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
+++ b/2/contrib/openshift/configuration/jobs/OpenShift Sample/config.xml
@@ -25,49 +25,51 @@
       <bldCfg>frontend</bldCfg>
       <namespace></namespace>
       <authToken></authToken>
-      <checkForTriggeredDeployments>true</checkForTriggeredDeployments>
+      <checkForTriggeredDeployments>false</checkForTriggeredDeployments>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftBuilder>
 
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
+    <com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
       <apiURL></apiURL>
-      <depCfg>frontend</depCfg>
       <namespace></namespace>
-      <replicaCount>0</replicaCount>
       <authToken></authToken>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
-
-    <com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
-      <apiURL></apiURL>
+      <verbose>false</verbose>
+      <waitTime></waitTime>
+      <waitUnit>sec</waitUnit>
       <depCfg>frontend</depCfg>
-      <namespace></namespace>
-      <replicaCount>1</replicaCount>
-      <authToken></authToken>
-      <verifyReplicaCount>true</verifyReplicaCount>
-    </com.openshift.jenkins.plugins.pipeline.OpenShiftScaler>
+    </com.openshift.jenkins.plugins.pipeline.OpenShiftDeployer>
     
     <com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
       <apiURL></apiURL>
-      <svcName>frontend</svcName>
       <namespace></namespace>
       <authToken></authToken>
+      <verbose>false</verbose>
+      <svcName>frontend</svcName>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftServiceVerifier>
-
+    
     <com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
       <apiURL></apiURL>
       <namespace></namespace>
+      <authToken></authToken>
+      <verbose>false</verbose>
       <testTag>latest</testTag>
       <prodTag>prod</prodTag>
       <testStream>origin-nodejs-sample</testStream>
       <prodStream>origin-nodejs-sample</prodStream>
-      <authToken></authToken>
+      <destinationNamespace></destinationNamespace>
+      <destinationAuthToken></destinationAuthToken>
+      <alias>false</alias>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftImageTagger>
 
     <com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
       <apiURL></apiURL>
-      <depCfg>frontend-prod</depCfg>
       <namespace></namespace>
-      <replicaCount>0</replicaCount>
       <authToken></authToken>
+      <verbose>false</verbose>
+      <waitTime></waitTime>
+      <waitUnit>milli</waitUnit>
+      <depCfg>frontend-prod</depCfg>
+      <replicaCount>1</replicaCount>
+      <verifyReplicaCount>false</verifyReplicaCount>
     </com.openshift.jenkins.plugins.pipeline.OpenShiftDeploymentVerifier>
 
   </builders>


### PR DESCRIPTION
@bparees PTAL

- bump pipeline plugin to 1.0.33 for a small regression introduced with the bugzilla fix for scaling beyond 1 replica
- updated sample job to adjust to the change in behavior with the example admin app's ICT going to auto=false
- included adding some of the newer fields to the config objs

@tdawson fyi v1.0.33