### PR TITLE
Revert "bump to LTS v2.19.3"

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -12,13 +12,13 @@ FROM centos:centos7
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 
-ENV JENKINS_VERSION=2.19 \
+ENV JENKINS_VERSION=2.7 \
     HOME=/var/lib/jenkins \
     JENKINS_HOME=/var/lib/jenkins \
     JENKINS_UC=https://updates.jenkins-ci.org
 
 LABEL k8s.io.description="Jenkins is a continuous integration server" \
-      k8s.io.display-name="Jenkins 2.19" \
+      k8s.io.display-name="Jenkins 2.7" \
       openshift.io.expose-services="8080:http" \
       openshift.io.tags="jenkins,jenkins1,ci" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
@@ -29,7 +29,7 @@ EXPOSE 8080 50000
 RUN curl http://pkg.jenkins-ci.org/redhat-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo && \
     rpm --import http://pkg.jenkins-ci.org/redhat-stable/jenkins-ci.org.key && \
     yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk-devel jenkins-2.19.3-1.1 nss_wrapper" && \
+    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk-devel jenkins-2.7.3-1.1 nss_wrapper" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all  && \


### PR DESCRIPTION
Reverts openshift/jenkins#200

this appears to have caused a mess.  I haven't checked yet if the rhel image has the same/similar issues.  @tdawson fyi.

```
SEVERE: Failed Loading plugin Favorite v2.0.2 (favorite)
java.io.IOException: Favorite v2.0.2 failed to load.
 - Matrix Project Plugin v1.7 is older than required. To fix, install v1.7.1 or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Module :: BlueOcean :: REST API implementation v1.0.0-b12 (blueocean-rest-impl)
java.io.IOException: Module :: BlueOcean :: REST API implementation v1.0.0-b12 failed to load.
 - Folders Plugin v5.11 is older than required. To fix, install v5.12 or later.
 - Favorite v2.0.2 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Supporting APIs v2.10 (workflow-support)
java.io.IOException: Pipeline: Supporting APIs v2.10 failed to load.
 - Script Security Plugin v1.19 is older than required. To fix, install v1.21 or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Groovy v2.22 (workflow-cps)
java.io.IOException: Pipeline: Groovy v2.22 failed to load.
 - Pipeline: Supporting APIs v2.9 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Nodes and Processes v2.5 (workflow-durable-task-step)
java.io.IOException: Pipeline: Nodes and Processes v2.5 failed to load.
 - Pipeline: Supporting APIs v2.1 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Job v2.8 (workflow-job)
java.io.IOException: Pipeline: Job v2.8 failed to load.
 - Pipeline: Supporting APIs v2.2 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Multibranch v2.7 (workflow-multibranch)
java.io.IOException: Pipeline: Multibranch v2.7 failed to load.
 - Pipeline: Groovy v2.3 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Jenkins Git plugin v3.0.0 (git)
java.io.IOException: Jenkins Git plugin v3.0.0 failed to load.
 - Matrix Project Plugin v1.7 is older than required. To fix, install v1.7.1 or later.
 - Credentials Plugin v2.1.0 is older than required. To fix, install v2.1.4 or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin GitHub plugin v1.23.1 (github)
java.io.IOException: GitHub plugin v1.23.1 failed to load.
 - Credentials Plugin v2.1.0 is older than required. To fix, install v2.1.8 or later.
 - Jenkins Git plugin v2.4.0 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin GitHub Branch Source Plugin v1.10 (github-branch-source)
java.io.IOException: GitHub Branch Source Plugin v1.10 failed to load.
 - GitHub plugin v1.14.1 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Input Step v2.0 (pipeline-input-step)
java.io.IOException: Pipeline: Input Step v2.0 failed to load.
 - Pipeline: Supporting APIs v1.15 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline Graph Analysis Plugin v1.2 (pipeline-graph-analysis)
java.io.IOException: Pipeline Graph Analysis Plugin v1.2 failed to load.
 - Pipeline: Groovy v2.2 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Module :: BlueOcean :: Pipeline REST API implementation v1.0.0-b12 (blueocean-pipeline-api-impl)
java.io.IOException: Module :: BlueOcean :: Pipeline REST API implementation v1.0.0-b12 failed to load.
 - Module :: BlueOcean :: REST API implementation v1.0.0-b12 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Module :: BlueOcean :: Events v1.0.0-b12 (blueocean-events)
java.io.IOException: Module :: BlueOcean :: Events v1.0.0-b12 failed to load.
 - Module :: BlueOcean :: Pipeline REST API implementation v1.0.0-b12 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Module :: BlueOcean :: Dashboard v1.0.0-b12 (blueocean-dashboard)
java.io.IOException: Module :: BlueOcean :: Dashboard v1.0.0-b12 failed to load.
 - Module :: BlueOcean :: Events v1.0.0-b12 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Module :: BlueOcean :: Personalization v1.0.0-b12 (blueocean-personalization)
java.io.IOException: Module :: BlueOcean :: Personalization v1.0.0-b12 failed to load.
 - Module :: BlueOcean :: Events v1.0.0-b12 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Credentials Binding Plugin v1.10 (credentials-binding)
java.io.IOException: Credentials Binding Plugin v1.10 failed to load.
 - Credentials Plugin v2.1.0 is older than required. To fix, install v2.1.7 or later.
 - Plain Credentials Plugin v1.2 is older than required. To fix, install v1.3 or later.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Docker Pipeline v1.9.1 (docker-workflow)
java.io.IOException: Docker Pipeline v1.9.1 failed to load.
 - Pipeline: Groovy v2.7 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Declarative Agent API v0.6 (pipeline-model-declarative-agent)
java.io.IOException: Pipeline: Declarative Agent API v0.6 failed to load.
 - Pipeline: Groovy v2.21 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Model Definition v0.6 (pipeline-model-definition)
java.io.IOException: Pipeline: Model Definition v0.6 failed to load.
 - Pipeline: Groovy v2.21 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin BlueOcean beta v1.0.0-b10 (blueocean)
java.io.IOException: BlueOcean beta v1.0.0-b10 failed to load.
 - Module :: BlueOcean :: Pipeline REST API implementation v1.0.0-b10 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: REST API Plugin v2.2 (pipeline-rest-api)
java.io.IOException: Pipeline: REST API Plugin v2.2 failed to load.
 - Pipeline Graph Analysis Plugin v1.1 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin OpenShift Sync v0.0.17 (openshift-sync)
java.io.IOException: OpenShift Sync v0.0.17 failed to load.
 - Pipeline: Job v2.8 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin OpenShift Pipeline Jenkins Plugin v1.0.35 (openshift-pipeline)
java.io.IOException: OpenShift Pipeline Jenkins Plugin v1.0.35 failed to load.
 - OpenShift Sync v0.0.11 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Build Step v2.1 (pipeline-build-step)
java.io.IOException: Pipeline: Build Step v2.1 failed to load.
 - Pipeline: Supporting APIs v1.15 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Stage View Plugin v2.2 (pipeline-stage-view)
java.io.IOException: Pipeline: Stage View Plugin v2.2 failed to load.
 - Pipeline: Job v2.0 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline Utility Steps v1.1.5 (pipeline-utility-steps)
java.io.IOException: Pipeline Utility Steps v1.1.5 failed to load.
 - Pipeline: Groovy v1.11 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline: Shared Groovy Libraries v2.4 (workflow-cps-global-lib)
java.io.IOException: Pipeline: Shared Groovy Libraries v2.4 failed to load.
 - Pipeline: Groovy v2.14 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Pipeline v2.1 (workflow-aggregator)
java.io.IOException: Pipeline v2.1 failed to load.
 - Pipeline: Stage View Plugin v1.3 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Nov 19, 2016 9:16:08 AM jenkins.InitReactorRunner$1 onTaskFailed
SEVERE: Failed Loading plugin Jenkins Pipeline Remote Loader Plugin v1.2 (workflow-remote-loader)
java.io.IOException: Jenkins Pipeline Remote Loader Plugin v1.2 failed to load.
 - Pipeline v1.11 failed to load. Fix this plugin first.
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:621)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:516)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:282)
	at jenkins.model.Jenkins$7.runTask(Jenkins.java:1038)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:210)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```