### PR TITLE
Simple check to allow for s2i build

### DIFF
--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -17,7 +17,8 @@ export HOME=${JENKINS_HOME}
 set -e
 
 # if `docker run` has 2 or more arguments the user is passing jenkins launcher arguments
-if [[ $# -gt 1 ]]; then
+# also check the JENKINS_URL  envar as this is useful for s2i builds
+if [ $# -gt 1 ] && [ ! -z $JENKINS_URL ]; then
   JAR="${JENKINS_HOME}/remoting.jar"
   PARAMS=""
 


### PR DESCRIPTION
Motivation:
A need for the 'slave-base' to be used as a base for a s2i build
The s2i build for some reason passes more than 2 parameters when executed and causes an error when trying to curl https://github.com/openshift/jenkins/blob/master/slave-base/contrib/bin/run-jnlp-client#L34

Changes:
A simple check for the JENKINS_URL envar (if empty will not error for s2i builds)

Please could you review and comment