### PR TITLE
Update to oc whoami regex to not exclude project names containing '-'.

### DIFF
--- a/1/contrib/jenkins/kube-slave-common.sh
+++ b/1/contrib/jenkins/kube-slave-common.sh
@@ -58,7 +58,7 @@ function has_service_account() {
 if has_service_account; then
   export oc_auth="--token=$(cat $AUTH_TOKEN) --certificate-authority=${KUBE_CA}"
   export oc_cmd="oc --server=$OPENSHIFT_API_URL ${oc_auth}"
-  export oc_serviceaccount_name="$(expr "$(oc whoami)" : 'system:serviceaccount:\w\+:\(\w\+\)' || true)"
+  export oc_serviceaccount_name="$(expr "$(oc whoami)" : 'system:serviceaccount:[a-z0-9][-a-z0-9]*:\([a-z0-9][-a-z0-9]*\)' || true)"
 fi
 
 # get_imagestream_names returns a list of image streams that match the

--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -58,7 +58,7 @@ function has_service_account() {
 if has_service_account; then
   export oc_auth="--token=$(cat $AUTH_TOKEN) --certificate-authority=${KUBE_CA}"
   export oc_cmd="oc --server=$OPENSHIFT_API_URL ${oc_auth}"
-  export oc_serviceaccount_name="$(expr "$(oc whoami)" : 'system:serviceaccount:\w\+:\(\w\+\)' || true)"
+  export oc_serviceaccount_name="$(expr "$(oc whoami)" : 'system:serviceaccount:[a-z0-9][-a-z0-9]*:\([a-z0-9][-a-z0-9]*\)' || true)"
 fi
 
 # get_imagestream_names returns a list of image streams that match the


### PR DESCRIPTION
The current `kube-slave-common.sh` script uses a regular expression to strip a service account name like 'system:serviceaccount:namespace:default' down to just the username, 'default'. However, the existing regex does not support all possible namespace/project names. Namely, a namespace like 'my-namespace' is a valid resource name, but '-' does not match the expression used in that script. The regex in this change more closely resembles the one used to validate namespace names in k8s, (`[a-z0-9]([-a-z0-9]*[a-z0-9])?`)

We can't quite match exactly what k8s uses because `expr` doesn't support extended regular expressions, but this is very close.

@bparees 