### PR TITLE
Added ruby slave based on enabling scl repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SKIP_SQUASH?=0
 # version (at least that is the initial goal).  This naming system
 # can be revisited in the future if we decide we need either jenkins
 # or <platform> version numbers in the names.
-VERSIONS="1 2 slave-base slave-maven slave-nodejs"
+VERSIONS="1 2 slave-base slave-maven slave-nodejs slave-ruby"
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7

--- a/slave-ruby/Dockerfile
+++ b/slave-ruby/Dockerfile
@@ -2,16 +2,6 @@ FROM openshift/jenkins-slave-base-centos7
 
 MAINTAINER Adam Saleh <asaleh@redhat.com>
 
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-slave-ruby-rhel7-docker" \
-      name="openshift3/jenkins-slave-ruby-rhel7" \
-      version="1" \
-      architecture="x86_64" \
-      release="1" \
-      io.k8s.display-name="Jenkins Slave Ruby" \
-      io.k8s.description="The jenkins slave ruby image has the ruby tools on top of the jenkins slave base image." \
-      io.openshift.tags="openshift,jenkins,slave,ruby"
-
 ENV RUBY_VERSION=2.3 \
     BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \

--- a/slave-ruby/Dockerfile
+++ b/slave-ruby/Dockerfile
@@ -1,0 +1,32 @@
+FROM openshift/jenkins-slave-base-centos7
+
+MAINTAINER Adam Saleh <asaleh@redhat.com>
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-slave-ruby-rhel7-docker" \
+      name="openshift3/jenkins-slave-ruby-rhel7" \
+      version="1" \
+      architecture="x86_64" \
+      release="1" \
+      io.k8s.display-name="Jenkins Slave Ruby" \
+      io.k8s.description="The jenkins slave ruby image has the ruby tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,slave,ruby"
+
+ENV RUBY_VERSION=2.3 \
+    BASH_ENV=/usr/local/bin/scl_enable \
+    ENV=/usr/local/bin/scl_enable \
+    PROMPT_COMMAND=". /usr/local/bin/scl_enable"
+
+COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
+
+# Install Ruby
+RUN yum install -y centos-release-scl-rh && \
+    INSTALL_PKGS="rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake rh-ruby23-rubygem-bundler" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/slave-ruby/Dockerfile.rhel7
+++ b/slave-ruby/Dockerfile.rhel7
@@ -1,0 +1,34 @@
+FROM openshift/jenkins-slave-base-rhel7
+
+MAINTAINER Adam Saleh <asaleh@redhat.com>
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-slave-ruby-rhel7-docker" \
+      name="openshift3/jenkins-slave-ruby-rhel7" \
+      version="1" \
+      architecture="x86_64" \
+      release="1" \
+      io.k8s.display-name="Jenkins Slave Ruby" \
+      io.k8s.description="The jenkins slave ruby image has the ruby tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,slave,ruby"
+
+ENV RUBY_VERSION=2.3 \
+    BASH_ENV=/usr/local/bin/scl_enable \
+    ENV=/usr/local/bin/scl_enable \
+    PROMPT_COMMAND=". /usr/local/bin/scl_enable"
+
+COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
+
+# Install Ruby
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \    
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --disable epel >/dev/null || : && \
+    INSTALL_PKGS="rh-ruby23 rh-ruby23-ruby-devel rh-ruby23-rubygem-rake rh-ruby23-rubygem-bundler" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/slave-ruby/cccp.yml
+++ b/slave-ruby/cccp.yml
@@ -1,0 +1,41 @@
+# This is for the purpose of building containers on the CentOS Community Container 
+# Pipeline. The containers are built, tested and delivered to registry.centos.org and
+# lifecycled as well. A corresponding entry must exist in the container index itself, 
+# located at https://github.com/CentOS/container-index/tree/master/index.d
+# You can know more at the following links:
+# * https://github.com/CentOS/container-pipeline-service/blob/master/README.md
+# * https://github.com/CentOS/container-index/blob/master/README.rst
+# * https://wiki.centos.org/ContainerPipeline
+
+# This will be part of the name of the container. It should match the job-id in index entry
+job-id: jenkins-slave-ruby-centos7 
+
+#the following are optional, can be left blank
+#defaults, where applicable are filled in
+#nulecule-file   : nulecule
+
+# This flag tells the container pipeline to skip user defined tests on their container
+test-skip       : True
+
+# This is path of the script that initiates the user defined tests. It must be able to
+# return an exit code.
+test-script     : null
+
+# This is the path of custom build script.
+build-script    : null
+
+# This is the path of the custom delivery script
+delivery-script : null
+
+# This flag tells the pipeline to deliver this container to docker hub.
+docker-index    : True
+
+# This flag can be used to enable or disable the custom delivery
+custom-delivery : False
+
+# This flag can be used to enable or disable delivery of container to local registry
+local-delivery  : True
+
+Upstreams       :
+        - ref           :
+          url           :

--- a/slave-ruby/contrib/bin/scl_enable
+++ b/slave-ruby/contrib/bin/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-ruby23

--- a/slave-ruby/test/run
+++ b/slave-ruby/test/run
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+#
+# Test the Jenkins image.
+#
+# IMAGE_NAME specifies the name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+# make sure oc is installed
+docker run ${IMAGE_NAME} oc
+# make sure npm and nodejs are available
+# the default entrypoint for the image assumes if you supply more than
+# one arg, you are trying to invoke the slave logic, so we have to
+# override the entrypoing to run complicated commands for testing.
+docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'gem --version'
+docker run --entrypoint=/bin/sh ${IMAGE_NAME} -ic 'ruby --version'
+
+echo "SUCCESS!"

--- a/slave-ruby/test/run
+++ b/slave-ruby/test/run
@@ -8,7 +8,7 @@
 
 # make sure oc is installed
 docker run ${IMAGE_NAME} oc
-# make sure npm and nodejs are available
+# make sure gem and ruby are available
 # the default entrypoint for the image assumes if you supply more than
 # one arg, you are trying to invoke the slave logic, so we have to
 # override the entrypoing to run complicated commands for testing.


### PR DESCRIPTION
Hi,

my team is planning to use Jenkins on Openshift, and we found a need to have a ruby based slave.
So I made one :-) 

So far 

```
make test VERSION=slave-ruby TARGET=centos7
```

ended up with 

```
2.5.1
sh: cannot set terminal process group (-1): Inappropriate ioctl for device
sh: no job control in this shell
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
SUCCESS!
```

where "2.5.1" and "ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]" are expected versions of both `gem --version` and `ruby --version` and I can report that we already are testing the image internally in our proof-of-concept jenkins pipe-lines.

So, anything more that needs to be done to have this in the official repo? 

Adam Saleh