### PR TITLE
Updates openshift-sync plugin to 0.1.7, which fixes bugs that break Jenkins pipeline builds

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -8,7 +8,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.4
+openshift-sync:0.1.7
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -8,7 +8,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.4
+openshift-sync:0.1.7
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1


### PR DESCRIPTION
A bug in  openshift-sync plugin breaks Jenkins pipeline builds:

Intermittent: Pipeline builds stop working after a while #113
https://github.com/openshift/openshift-jenkins-sync-plugin/issues/113

Bug 1406306 - jenkinsPipelineStrategy BC won't work after master/node services restart and Jenkins pod will log "SEVERE: Failed to update job"
https://bugzilla.redhat.com/show_bug.cgi?id=1406306

It's fixed in openshift-sync plugin v0.1.7 https://github.com/jenkinsci/openshift-sync-plugin/releases/tag/v0.1.7

This PR updates the version openshift-sync plugin in base-plugins to 0.1.7
