### PR TITLE
add java i386 arch

### DIFF
--- a/1/Dockerfile
+++ b/1/Dockerfile
@@ -28,7 +28,7 @@ EXPOSE 8080 50000
 RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo && \
     rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key && \
     yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk-devel jenkins-1.651.3-1.1 nss_wrapper" && \
+    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 jenkins-1.651.3-1.1" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all  && \
@@ -48,6 +48,36 @@ RUN /usr/local/bin/plugins.sh /opt/openshift/base-plugins.txt && \
     touch /opt/openshift/plugins/subversion.jpi.pinned && \
     touch /opt/openshift/plugins/ssh-credentials.jpi.pinned && \
     touch /opt/openshift/plugins/script-security.jpi.pinned && \
+    chmod 775 /etc/passwd && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/lib/jvm-exports && \
+    chmod 775 /usr/share/man/man1 && \
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/orbd && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/policytool && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/servertool && \
+    unlink /usr/bin/tnameserv && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/lib/jvm-exports/jre && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/orbd.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/policytool.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/servertool.1.gz && \
+    unlink /usr/share/man/man1/tnameserv.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz && \
     chown -R 1001:0 /opt/openshift && \
     rmdir /var/log/jenkins && \
     /usr/local/bin/fix-permissions /opt/openshift && \

--- a/1/Dockerfile.rhel7
+++ b/1/Dockerfile.rhel7
@@ -35,7 +35,7 @@ EXPOSE 8080 50000
 
 RUN yum-config-manager --disable epel >/dev/null || : && \
     yum-config-manager --enable rhel-7-server-ose-3.3-rpms || : && \
-    INSTALL_PKGS="rsync gettext git tar zip unzip nss_wrapper java-1.8.0-openjdk java-1.8.0-openjdk-devel atomic-openshift-clients jenkins-1.651.2 jenkins-plugin-kubernetes jenkins-plugin-openshift-pipeline jenkins-plugin-openshift-login jenkins-plugin-credentials jenkins-plugin-ace-editor jenkins-plugin-branch-api jenkins-plugin-cloudbees-folder jenkins-plugin-durable-task jenkins-plugin-git jenkins-plugin-git-client jenkins-plugin-git-server jenkins-plugin-handlebars jenkins-plugin-jquery-detached jenkins-plugin-mapdb-api jenkins-plugin-matrix-project jenkins-plugin-mercurial jenkins-plugin-momentjs jenkins-plugin-multiple-scms jenkins-plugin-pipeline-build-step jenkins-plugin-pipeline-graph-analysis jenkins-plugin-pipeline-input-step jenkins-plugin-pipeline-rest-api jenkins-plugin-pipeline-stage-step jenkins-plugin-pipeline-stage-view jenkins-plugin-pipeline-utility-steps jenkins-plugin-plain-credentials jenkins-plugin-scm-api jenkins-plugin-script-security jenkins-plugin-ssh-credentials jenkins-plugin-structs jenkins-plugin-subversion jenkins-plugin-workflow-aggregator jenkins-plugin-workflow-api jenkins-plugin-workflow-basic-steps jenkins-plugin-workflow-cps jenkins-plugin-workflow-cps-global-lib jenkins-plugin-workflow-durable-task-step jenkins-plugin-workflow-job jenkins-plugin-workflow-multibranch jenkins-plugin-workflow-remote-loader jenkins-plugin-workflow-scm-step jenkins-plugin-workflow-step-api jenkins-plugin-workflow-step-api jenkins-plugin-workflow-support jenkins-plugin-openshift-sync" && \
+    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 atomic-openshift-clients jenkins-1.651.2 jenkins-plugin-kubernetes jenkins-plugin-openshift-pipeline jenkins-plugin-openshift-login jenkins-plugin-credentials jenkins-plugin-ace-editor jenkins-plugin-branch-api jenkins-plugin-cloudbees-folder jenkins-plugin-durable-task jenkins-plugin-git jenkins-plugin-git-client jenkins-plugin-git-server jenkins-plugin-handlebars jenkins-plugin-jquery-detached jenkins-plugin-mapdb-api jenkins-plugin-matrix-project jenkins-plugin-mercurial jenkins-plugin-momentjs jenkins-plugin-multiple-scms jenkins-plugin-pipeline-build-step jenkins-plugin-pipeline-graph-analysis jenkins-plugin-pipeline-input-step jenkins-plugin-pipeline-rest-api jenkins-plugin-pipeline-stage-step jenkins-plugin-pipeline-stage-view jenkins-plugin-pipeline-utility-steps jenkins-plugin-plain-credentials jenkins-plugin-scm-api jenkins-plugin-script-security jenkins-plugin-ssh-credentials jenkins-plugin-structs jenkins-plugin-subversion jenkins-plugin-workflow-aggregator jenkins-plugin-workflow-api jenkins-plugin-workflow-basic-steps jenkins-plugin-workflow-cps jenkins-plugin-workflow-cps-global-lib jenkins-plugin-workflow-durable-task-step jenkins-plugin-workflow-job jenkins-plugin-workflow-multibranch jenkins-plugin-workflow-remote-loader jenkins-plugin-workflow-scm-step jenkins-plugin-workflow-step-api jenkins-plugin-workflow-step-api jenkins-plugin-workflow-support jenkins-plugin-openshift-sync" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all  && \
@@ -59,6 +59,36 @@ RUN rm /opt/openshift/base-plugins.txt && \
     touch /opt/openshift/plugins/script-security.jpi.pinned && \
     touch /opt/openshift/plugins/matrix-project.jpi.pinned && \
     rmdir /var/log/jenkins && \
+    chmod 775 /etc/passwd && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/lib/jvm-exports && \
+    chmod 775 /usr/share/man/man1 && \
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/orbd && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/policytool && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/servertool && \
+    unlink /usr/bin/tnameserv && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/lib/jvm-exports/jre && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/orbd.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/policytool.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/servertool.1.gz && \
+    unlink /usr/share/man/man1/tnameserv.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     chown -R 1001:0 /opt/openshift && \
     # the prior chown doesn't traverse the /opt/openshift/plugins links .. this one will assist fix-permission/assemble for extension builds like master/slave

--- a/1/contrib/jenkins/jenkins-common.sh
+++ b/1/contrib/jenkins/jenkins-common.sh
@@ -16,15 +16,8 @@ function generate_passwd_file() {
 
   if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"997" ]; then
 
-    NSS_WRAPPER_PASSWD=/opt/openshift/passwd
-    NSS_WRAPPER_GROUP=/etc/group
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd
 
-    cp /etc/passwd $NSS_WRAPPER_PASSWD
-    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
-
-    export NSS_WRAPPER_PASSWD
-    export NSS_WRAPPER_GROUP
-    export LD_PRELOAD=libnss_wrapper.so
   fi
 }
 

--- a/1/contrib/s2i/run
+++ b/1/contrib/s2i/run
@@ -9,38 +9,55 @@
 source /usr/local/bin/jenkins-common.sh
 source /usr/local/bin/kube-slave-common.sh
 
+#get the fully qualified paths to both 32 and 64 bit java
+JVMPath32bit=`alternatives --display java | grep family | grep i386 | awk '{print $1}'`
+JVMPath64bit=`alternatives --display java | grep family | grep x86_64 | awk '{print $1}'`
+
+
+# set the java version used based on OPENSHIFT_JENKINS_JVM_ARCH
+if [ -z $OPENSHIFT_JENKINS_JVM_ARCH  ]; then
+    echo "Using 64 bit Java since OPENSHIFT_JENKINS_JVM_ARCH is not set (historic setting)"
+    alternatives --set java $JVMPath64bit
+elif [ "${OPENSHIFT_JENKINS_JVM_ARCH}" == "x86_64"  ]; then
+    echo "64 bit Java explicitly set in OPENSHIFT_JENKINS_JVM_ARCH"
+    alternatives --set java $JVMPath64bit
+else
+    echo "OPENSHIFT_JENKINS_JVM_ARCH is set to ${OPENSHIFT_JENKINS_JVM_ARCH} so using 32 bit Java"
+    alternatives --set java $JVMPath32bit
+fi
+
 image_config_dir="/opt/openshift/configuration"
 image_config_path="${image_config_dir}/config.xml"
-
 
 CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
 DEFAULT_MEMORY_CEILING=$((2**40-1))
 if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
 
     if [ -z $CONTAINER_HEAP_PERCENT ]; then
-        LOW_MEMORY_THRESHOLD=$((640*2**20)) # 640M
-        if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${LOW_MEMORY_THRESHOLD}" ]; then
-            # If the user is not actively tailoring environment variables to adjust memory use,
-            # then tailor the runtime for limited memory automatically.
-            CONTAINER_HEAP_PERCENT=0.40
-            LOW_MEMORY_PARAMS="-Xss500K"
-        else
-            CONTAINER_HEAP_PERCENT=0.50
-        fi
+        CONTAINER_HEAP_PERCENT=0.50
     fi
     
     CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
+    #if machine has 4GB or less, meaning max heap of 2GB given current default, force use of 32bit to save space unless user
+    #specifically want to force 64bit
+    HEAP_LIMIT_FOR_32BIT=$((2**32-1))
+    HEAP_LIMIT_FOR_32BIT_IN_MB=$((${HEAP_LIMIT_FOR_32BIT}/1024**2))
     CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    if [[ -z $OPENSHIFT_JENKINS_JVM_ARCH && "${CONTAINER_HEAP_MAX}" -lt "${HEAP_LIMIT_FOR_32BIT_IN_MB}"  ]]; then
+	echo "max heap in MB is ${CONTAINER_HEAP_MAX} and 64 bit was not explicitly set so using 32 bit Java"
+	alternatives --set java $JVMPath32bit
+    fi
     
     JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
 fi 
 
 if [ -z $JAVA_GC_OPTS ]; then
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+  # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
+  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 fi
 
 # Since OpenShift runs this Docker image under random user ID, we have to assign
-# the 'jenkins' user name to this UID. For that we use nss_wrapper
+# the 'jenkins' user name to this UID.
 generate_passwd_file
 
 mkdir /tmp/war
@@ -126,7 +143,7 @@ fi
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JAVA_GC_OPTS $JAVA_MAX_HEAP_PARAM $LOW_MEMORY_PARAMS -Duser.home=${HOME} $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java $JAVA_GC_OPTS $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/1/test/run
+++ b/1/test/run
@@ -103,11 +103,10 @@ function test_get_job() {
 
 function run_tests() {
   local name=$1 ; shift
-  CONTAINER_ARGS="-u 10000:0"
   create_container $name $VOLUME
   CONTAINER_IP=$(get_container_ip $name)
   test_connection $name
- 
+
   # Make sure no plugins failed to load
   set +e
   CONTAINER=$(cat $cidfile)
@@ -192,6 +191,16 @@ function run_s2i_tests() {
 # Tests.
 
 # Normal tests
+echo "Normal test: 64 bit"
+CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=x86_64"
+run_tests jenkins_test
+cleanup
+sleep 5
+echo "Normal test: 32 bit"
+CIDFILE_DIR=$(mktemp --suffix=jenkins_test_cidfiles -d)
+VOLUME=`mktemp -d`
+chmod a+rwx $VOLUME
+CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=i386 "
 run_tests jenkins_test
 
 # S2I tests

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -31,7 +31,7 @@ EXPOSE 8080 50000
 RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo && \
     rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key && \
     yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk-devel jenkins-2.32.2-1.1 nss_wrapper" && \
+    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 jenkins-2.32.2-1.1" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all  && \
@@ -50,6 +50,36 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/base-plugins.txt && \
     # Currently jenkins v2 does not embed any plugins, but for reference:
     # touch /opt/openshift/plugins/credentials.jpi.pinned && \
     rmdir /var/log/jenkins && \
+    chmod 775 /etc/passwd && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/lib/jvm-exports && \
+    chmod 775 /usr/share/man/man1 && \
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/orbd && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/policytool && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/servertool && \
+    unlink /usr/bin/tnameserv && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/lib/jvm-exports/jre && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/orbd.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/policytool.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/servertool.1.gz && \
+    unlink /usr/share/man/man1/tnameserv.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz && \
     chown -R 1001:0 /opt/openshift && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     /usr/local/bin/fix-permissions /var/lib/jenkins && \

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -35,7 +35,7 @@ EXPOSE 8080 50000
 
 RUN yum-config-manager --disable epel >/dev/null || : && \
     yum-config-manager --enable rhel-7-server-ose-3.3-rpms || : && \
-    INSTALL_PKGS="rsync gettext git tar zip unzip nss_wrapper java-1.8.0-openjdk java-1.8.0-openjdk-devel atomic-openshift-clients jenkins-2.7.4 jenkins-plugin-ace-editor jenkins-plugin-branch-api jenkins-plugin-cloudbees-folder jenkins-plugin-credentials jenkins-plugin-display-url-api jenkins-plugin-durable-task jenkins-plugin-git jenkins-plugin-git-client jenkins-plugin-git-server jenkins-plugin-handlebars jenkins-plugin-icon-shim jenkins-plugin-jquery-detached jenkins-plugin-junit jenkins-plugin-kubernetes jenkins-plugin-mailer jenkins-plugin-mapdb-api jenkins-plugin-matrix-project jenkins-plugin-matrix-auth jenkins-plugin-mercurial jenkins-plugin-momentjs jenkins-plugin-multiple-scms jenkins-plugin-openshift-pipeline jenkins-plugin-openshift-login jenkins-plugin-openshift-sync jenkins-plugin-pipeline-build-step jenkins-plugin-pipeline-graph-analysis jenkins-plugin-pipeline-input-step jenkins-plugin-pipeline-rest-api jenkins-plugin-pipeline-stage-step jenkins-plugin-pipeline-stage-view jenkins-plugin-pipeline-utility-steps jenkins-plugin-plain-credentials jenkins-plugin-scm-api jenkins-plugin-script-security jenkins-plugin-ssh-credentials jenkins-plugin-structs jenkins-plugin-subversion jenkins-plugin-workflow-aggregator jenkins-plugin-workflow-api jenkins-plugin-workflow-basic-steps jenkins-plugin-workflow-cps jenkins-plugin-workflow-cps-global-lib jenkins-plugin-workflow-durable-task-step jenkins-plugin-workflow-job jenkins-plugin-workflow-multibranch jenkins-plugin-workflow-remote-loader jenkins-plugin-workflow-scm-step jenkins-plugin-workflow-step-api jenkins-plugin-workflow-step-api jenkins-plugin-workflow-support" && \
+    INSTALL_PKGS="rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 atomic-openshift-clients jenkins-2.7.4 jenkins-plugin-ace-editor jenkins-plugin-branch-api jenkins-plugin-cloudbees-folder jenkins-plugin-credentials jenkins-plugin-display-url-api jenkins-plugin-durable-task jenkins-plugin-git jenkins-plugin-git-client jenkins-plugin-git-server jenkins-plugin-handlebars jenkins-plugin-icon-shim jenkins-plugin-jquery-detached jenkins-plugin-junit jenkins-plugin-kubernetes jenkins-plugin-mailer jenkins-plugin-mapdb-api jenkins-plugin-matrix-project jenkins-plugin-matrix-auth jenkins-plugin-mercurial jenkins-plugin-momentjs jenkins-plugin-multiple-scms jenkins-plugin-openshift-pipeline jenkins-plugin-openshift-login jenkins-plugin-openshift-sync jenkins-plugin-pipeline-build-step jenkins-plugin-pipeline-graph-analysis jenkins-plugin-pipeline-input-step jenkins-plugin-pipeline-rest-api jenkins-plugin-pipeline-stage-step jenkins-plugin-pipeline-stage-view jenkins-plugin-pipeline-utility-steps jenkins-plugin-plain-credentials jenkins-plugin-scm-api jenkins-plugin-script-security jenkins-plugin-ssh-credentials jenkins-plugin-structs jenkins-plugin-subversion jenkins-plugin-workflow-aggregator jenkins-plugin-workflow-api jenkins-plugin-workflow-basic-steps jenkins-plugin-workflow-cps jenkins-plugin-workflow-cps-global-lib jenkins-plugin-workflow-durable-task-step jenkins-plugin-workflow-job jenkins-plugin-workflow-multibranch jenkins-plugin-workflow-remote-loader jenkins-plugin-workflow-scm-step jenkins-plugin-workflow-step-api jenkins-plugin-workflow-step-api jenkins-plugin-workflow-support" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all  && \
@@ -52,6 +52,36 @@ RUN rm /opt/openshift/base-plugins.txt && \
     # NOTE: When adding new Jenkins plugin, you have to create the symlink for the
     # HPI file created by rpm to /opt/openshift/plugins folder.
     for FILENAME in /usr/lib64/jenkins/*hpi ; do ln -s $FILENAME /opt/openshift/plugins/`basename $FILENAME .hpi`.jpi; done &&\
+    chmod 775 /etc/passwd && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/lib/jvm-exports && \
+    chmod 775 /usr/share/man/man1 && \
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/orbd && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/policytool && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/servertool && \
+    unlink /usr/bin/tnameserv && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/lib/jvm-exports/jre && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/orbd.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/policytool.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/servertool.1.gz && \
+    unlink /usr/share/man/man1/tnameserv.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz && \
     # need to create <plugin>.pinned files when upgrading "core" plugins like credentials or subversion that are bundled with the jenkins server
     # Currently jenkins v2 does not embed any plugins, but for reference:
     # touch /opt/openshift/plugins/credentials.jpi.pinned && \

--- a/2/contrib/jenkins/jenkins-common.sh
+++ b/2/contrib/jenkins/jenkins-common.sh
@@ -16,15 +16,8 @@ function generate_passwd_file() {
 
   if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"997" ]; then
 
-    NSS_WRAPPER_PASSWD=/opt/openshift/passwd
-    NSS_WRAPPER_GROUP=/etc/group
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd
 
-    cp /etc/passwd $NSS_WRAPPER_PASSWD
-    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
-
-    export NSS_WRAPPER_PASSWD
-    export NSS_WRAPPER_GROUP
-    export LD_PRELOAD=libnss_wrapper.so
   fi
 }
 

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -9,38 +9,55 @@
 source /usr/local/bin/jenkins-common.sh
 source /usr/local/bin/kube-slave-common.sh
 
+#get the fully qualified paths to both 32 and 64 bit java
+JVMPath32bit=`alternatives --display java | grep family | grep i386 | awk '{print $1}'`
+JVMPath64bit=`alternatives --display java | grep family | grep x86_64 | awk '{print $1}'`
+
+
+# set the java version used based on OPENSHIFT_JENKINS_JVM_ARCH
+if [ -z $OPENSHIFT_JENKINS_JVM_ARCH  ]; then
+    echo "Using 64 bit Java since OPENSHIFT_JENKINS_JVM_ARCH is not set (historic setting)"
+    alternatives --set java $JVMPath64bit
+elif [ "${OPENSHIFT_JENKINS_JVM_ARCH}" == "x86_64"  ]; then
+    echo "64 bit Java explicitly set in OPENSHIFT_JENKINS_JVM_ARCH"
+    alternatives --set java $JVMPath64bit
+else
+    echo "OPENSHIFT_JENKINS_JVM_ARCH is set to ${OPENSHIFT_JENKINS_JVM_ARCH} so using 32 bit Java"
+    alternatives --set java $JVMPath32bit
+fi
+
 image_config_dir="/opt/openshift/configuration"
 image_config_path="${image_config_dir}/config.xml"
-
 
 CONTAINER_MEMORY_IN_BYTES=`cat /sys/fs/cgroup/memory/memory.limit_in_bytes`
 DEFAULT_MEMORY_CEILING=$((2**40-1))
 if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
 
     if [ -z $CONTAINER_HEAP_PERCENT ]; then
-        LOW_MEMORY_THRESHOLD=$((640*2**20)) # 640M
-        if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${LOW_MEMORY_THRESHOLD}" ]; then
-            # If the user is not actively tailoring environment variables to adjust memory use,
-            # then tailor the runtime for limited memory automatically.
-            CONTAINER_HEAP_PERCENT=0.40
-            LOW_MEMORY_PARAMS="-Xss500K"
-        else
-            CONTAINER_HEAP_PERCENT=0.50
-        fi
+        CONTAINER_HEAP_PERCENT=0.50
     fi
     
     CONTAINER_MEMORY_IN_MB=$((${CONTAINER_MEMORY_IN_BYTES}/1024**2))
+    #if machine has 4GB or less, meaning max heap of 2GB given current default, force use of 32bit to save space unless user
+    #specifically want to force 64bit
+    HEAP_LIMIT_FOR_32BIT=$((2**32-1))
+    HEAP_LIMIT_FOR_32BIT_IN_MB=$((${HEAP_LIMIT_FOR_32BIT}/1024**2))
     CONTAINER_HEAP_MAX=$(echo "${CONTAINER_MEMORY_IN_MB} ${CONTAINER_HEAP_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    if [[ -z $OPENSHIFT_JENKINS_JVM_ARCH && "${CONTAINER_HEAP_MAX}" -lt "${HEAP_LIMIT_FOR_32BIT_IN_MB}"  ]]; then
+	echo "max heap in MB is ${CONTAINER_HEAP_MAX} and 64 bit was not explicitly set so using 32 bit Java"
+	alternatives --set java $JVMPath32bit
+    fi
     
     JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
 fi 
 
 if [ -z $JAVA_GC_OPTS ]; then
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
+  # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
+  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 fi
 
 # Since OpenShift runs this Docker image under random user ID, we have to assign
-# the 'jenkins' user name to this UID. For that we use nss_wrapper
+# the 'jenkins' user name to this UID.
 generate_passwd_file
 
 mkdir /tmp/war
@@ -126,7 +143,7 @@ fi
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JAVA_GC_OPTS $JAVA_MAX_HEAP_PARAM $LOW_MEMORY_PARAMS -Duser.home=${HOME} $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java $JAVA_GC_OPTS $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/2/test/run
+++ b/2/test/run
@@ -103,7 +103,6 @@ function test_get_job() {
 
 function run_tests() {
   local name=$1 ; shift
-  CONTAINER_ARGS="-u 10000:0"
   create_container $name $VOLUME
   CONTAINER_IP=$(get_container_ip $name)
   test_connection $name
@@ -192,6 +191,16 @@ function run_s2i_tests() {
 # Tests.
 
 # Normal tests
+echo "Normal test: 64 bit"
+CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=x86_64"
+run_tests jenkins_test
+cleanup
+sleep 5
+echo "Normal test: 32 bit"
+CIDFILE_DIR=$(mktemp --suffix=jenkins_test_cidfiles -d)
+VOLUME=`mktemp -d`
+chmod a+rwx $VOLUME
+CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=i386 "
 run_tests jenkins_test
 
 # S2I tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-SKIP_SQUASH?=0
 # The master images follow the normal numbering scheme in which the
 # major version is used as the directory name and incorporated into
 # the image name (jenkins-1-centos7 in this case).  For the slave
@@ -19,8 +18,8 @@ endif
 
 .PHONY: build
 build:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
+	VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
 
 .PHONY: test
 test:
-	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)
+	VERSIONS=$(VERSIONS) TAG_ON_SUCCESS=$(TAG_ON_SUCCESS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -27,20 +27,7 @@ function docker_build_with_version {
   git_version=$(git rev-parse --short HEAD)
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
   docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
-  if [[ "${SKIP_SQUASH}" != "1" ]]; then
-    squash "${dockerfile}.version"
-  fi
   rm -f "${DOCKERFILE_PATH}.version"
-}
-
-# Install the docker squashing tool[1] and squash the result image
-# [1] https://github.com/goldmann/docker-squash
-function squash {
-  # FIXME: We have to use the exact versions here to avoid Docker client
-  #        compatibility issues
-  easy_install -q --user docker_py==1.6.0 docker-squash==1.0.0rc6
-  base=$(awk '/^FROM/{print $2}' $1)
-  ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME}
 }
 
 # Versions are stored in subdirectories. You can specify VERSION variable

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -7,13 +7,14 @@ ENV HOME=/home/jenkins
 USER root
 # Install headless Java
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof nss_wrapper rsync tar unzip which zip" && \
+    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless java-1.8.0-openjdk-headless.i686 lsof rsync tar unzip which zip" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \
+    chmod 775 /etc/passwd && \
     set -o pipefail && curl -L https://github.com/openshift/origin/releases/download/v1.4.1/openshift-origin-client-tools-v1.4.1-3f9807a-linux-64bit.tar.gz | \
     tar -zx && \
     mv openshift*/oc /usr/local/bin && \

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -17,7 +17,7 @@ ENV HOME=/home/jenkins
 USER root
 # Install headless Java
 RUN yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="atomic-openshift-clients bc gettext git java-1.8.0-openjdk-headless lsof nss_wrapper rsync tar unzip which zip" && \
+    INSTALL_PKGS="atomic-openshift-clients bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all && \

--- a/slave-base/contrib/bin/generate_container_user
+++ b/slave-base/contrib/bin/generate_container_user
@@ -4,14 +4,6 @@ GROUP_ID=$(id -g)
 
 if [ x"$USER_ID" != x"0" ]; then
 
-    NSS_WRAPPER_PASSWD=/tmp/nss_passwd
-    NSS_WRAPPER_GROUP=/etc/group
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd
 
-    cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
-
-    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
-
-    export NSS_WRAPPER_PASSWD
-    export NSS_WRAPPER_GROUP
-    export LD_PRELOAD=libnss_wrapper.so
 fi

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -6,6 +6,22 @@
 
 source /usr/local/bin/generate_container_user
 
+#get the fully qualified paths to both 32 and 64 bit java
+JVMPath32bit=`alternatives --display java | grep family | grep i386 | awk '{print $1}'`
+JVMPath64bit=`alternatives --display java | grep family | grep x86_64 | awk '{print $1}'`
+
+# set the java version used based on OPENSHIFT_JENKINS_JVM_ARCH
+if [ -z $OPENSHIFT_JENKINS_JVM_ARCH  ]; then
+    echo "Using 64 bit Java since OPENSHIFT_JENKINS_JVM_ARCH is not set"
+    alternatives --set java $JVMPath64bit
+elif [ "${OPENSHIFT_JENKINS_JVM_ARCH}" == "x86_64"  ]; then
+    echo "64 bit Java explicitly set in OPENSHIFT_JENKINS_JVM_ARCH"
+    alternatives --set java $JVMPath64bit
+else
+    echo "OPENSHIFT_JENKINS_JVM_ARCH is set to ${OPENSHIFT_JENKINS_JVM_ARCH} so using 32 bit Java"
+    alternatives --set java $JVMPath32bit
+fi
+
 # The directory that Jenkins will execute the builds and store cache files.
 # The directory has to be writeable for the user that the container is running
 # under.


### PR DESCRIPTION
@bparees PTAL

*** NOTE *** 

I wanted to see what it would take to use `alternatives` to manage the java version as the `1001` user, since `alternatives` is a more complete switch (handles everything, not just the `java` binary).

Here are the updates for centos and jenkins v1 and v2.

Based on how the review goes, I'll circle back and start looking into updating the rhel image.