### PR TITLE
goto v1.0.42 of openshift-pipeline

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.40
+openshift-pipeline:1.0.42
 openshift-login:0.11
 
 

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-pipeline:1.0.40
+openshift-pipeline:1.0.42
 openshift-login:0.11
 
 


### PR DESCRIPTION
@bparees PTAL - a couple of github issue / bugzilla fixes.

@tdawson - FYI - for the bugzilla, we'll need a 1.0.42 RPM for openshift-pipeline and versions of the openshift jenkins-*-rhel7 built with that RPM out on brew-pulp for defect verification.  I'll tag you in the bugzilla in question.

thanks