### PR TITLE
Change the default Kubernetes cloud name to 'kubernetes' 

### DIFF
--- a/1/contrib/jenkins/kube-slave-common.sh
+++ b/1/contrib/jenkins/kube-slave-common.sh
@@ -126,7 +126,7 @@ function generate_kubernetes_config() {
     local crt_contents=$(cat "${KUBE_CA}")
     echo "
     <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
-      <name>openshift</name>
+      <name>kubernetes</name>
       <templates>
         <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
           <inheritFrom></inheritFrom>

--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -126,7 +126,7 @@ function generate_kubernetes_config() {
     local crt_contents=$(cat "${KUBE_CA}")
     echo "
     <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
-      <name>openshift</name>
+      <name>kubernetes</name>
       <templates>
         <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
           <inheritFrom></inheritFrom>


### PR DESCRIPTION
The old name 'openshift' of the kubernetes cloud is not recognized by the Kubernetes plugin. When a job with a node label 'maven' or 'nodejs' is run, there will be an error from the Kubernetes plugin saying cannot find the cloud 'kubernetes'.  After rename the cloud to 'kunbernetes' this issue is gone. Tested with Jenkins 2.7.3 and Kubernetes plugin 0.10.