### PR TITLE
more jenkins plugin churn (scmapi, jquery-detached)

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -32,14 +32,13 @@ cloudbees-folder:5.17
 
 # Pipeline stage view plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin
 pipeline-stage-view:2.2
-jquery-detached:1.2.1
 handlebars:1.1.1
 pipeline-rest-api:2.2
 momentjs:1.1.1
 
 # remote loader https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin
 workflow-remote-loader:1.2
-scm-api:2.0.3
+scm-api:2.0.4
 branch-api:2.0.2
 
 # Pipeline SCM Step Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+SCM+Step+Plugin


### PR DESCRIPTION
@bparees  - more scm-api churn on v2

also, jquery-detached failed to download in v2 testing.  Uncovered that
a) https://updates.jenkins-ci.org/download/plugins/jquery-detached-plugin now gets a 404 / not found
b) per https://wiki.jenkins-ci.org/display/JENKINS/jQuery+Detached+Plugin you should not install this plugin directory

Interestingly, even after clearing my docker image cache, jquery-detached still downloaded and built with v1.  At first blush don't understand why.  We'll see how subsequent tests turn out.