### PR TITLE
Bump Pipeline Shared Groovy Libraries Plugin to version 2.6

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -20,7 +20,7 @@ workflow-aggregator:2.1
 workflow-api:2.8
 workflow-basic-steps:2.3
 workflow-cps:2.25
-workflow-cps-global-lib:2.5
+workflow-cps-global-lib:2.6
 workflow-durable-task-step:2.8
 workflow-job:2.9
 workflow-step-api:2.8

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -32,14 +32,13 @@ cloudbees-folder:5.17
 
 # Pipeline stage view plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin
 pipeline-stage-view:2.2
-jquery-detached:1.2.1
 handlebars:1.1.1
 pipeline-rest-api:2.2
 momentjs:1.1.1
 
 # remote loader https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin
 workflow-remote-loader:1.2
-scm-api:2.0.3
+scm-api:2.0.4
 branch-api:2.0.2
 
 # Pipeline SCM Step Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+SCM+Step+Plugin


### PR DESCRIPTION
Version 2.5 of the plugin breaks the openshift client plugin
Requires change from https://github.com/openshift/jenkins/pull/248
