### PR TITLE
bump sync pluging to 0.1.8

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.7
+openshift-sync:0.1.8
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.11
 
 # fabric8 openshift sync
-openshift-sync:0.1.7
+openshift-sync:0.1.8
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1


### PR DESCRIPTION
@bparees fyi for https://trello.com/c/h6NSFQgk/1052-5-allow-env-variables-on-pipeline-buildconfigs-techdebt-pipeline-integration

`make test VERSIONS=2` worked locally for me after clearing out my jenkins image cache ... let's see how stable upstream plugin dependencies are 