### PR TITLE
Bump sync

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.10
+openshift-sync:0.1.11
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.11
 
 # fabric8 openshift sync
-openshift-sync:0.1.10
+openshift-sync:0.1.11
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -4,9 +4,9 @@ openshift-client:0.9.2
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
-durable-task:1.12
+durable-task:1.13
 kubernetes:0.10
-credentials:2.1.11
+credentials:2.1.13
 
 # fabric8 openshift sync
 openshift-sync:0.1.11
@@ -17,18 +17,18 @@ pipeline-graph-analysis:1.3
 pipeline-input-step:2.5
 pipeline-stage-step:2.2
 workflow-aggregator:2.1
-workflow-api:2.8
+workflow-api:2.12
 workflow-basic-steps:2.3
-workflow-cps:2.25
+workflow-cps:2.29
 workflow-cps-global-lib:2.6
-workflow-durable-task-step:2.8
-workflow-job:2.9
-workflow-step-api:2.8
-workflow-support:2.12
+workflow-durable-task-step:2.9
+workflow-job:2.10
+workflow-step-api:2.9
+workflow-support:2.13
 
 # Pipeline Multibranch Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Plugin
 workflow-multibranch:2.12
-cloudbees-folder:5.17
+cloudbees-folder:5.18
 
 # Pipeline stage view plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin
 pipeline-stage-view:2.2
@@ -38,12 +38,12 @@ momentjs:1.1.1
 
 # remote loader https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin
 workflow-remote-loader:1.2
-scm-api:2.0.4
-branch-api:2.0.2
+scm-api:2.1.0
+branch-api:2.0.7
 
 # Pipeline SCM Step Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+SCM+Step+Plugin
-workflow-scm-step:2.3
-git:3.0.4
+workflow-scm-step:2.4
+git:3.1.0
 mapdb-api:1.0.1.0
 subversion:2.5.7
 
@@ -55,11 +55,11 @@ ssh-credentials:1.12
 
 # Pipeline Utility Steps Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Utility+Steps+Plugin
 pipeline-utility-steps:1.1.5
-script-security:1.25
+script-security:1.26
 
 # seem to be missing from the Jenkins docs but required to run these plugins..
-structs:1.5
-git-client:2.1.0
+structs:1.6
+git-client:2.3.0
 git-server:1.6
 plain-credentials:1.3
 ace-editor:1.1


### PR DESCRIPTION
... as well as the next round of upstream jenkins plugin churn

@tdawson - in addition to the bug fix for openshift-sync there I mentioned [here](https://github.com/openshift/jenkins/pull/254#issuecomment-285424673), the now expected churn in upstream jenkins plugins for our jenkins 2 image occurred.  We'll need RPMs for those built in addition to the new openshift-sync RPM as part of building the 3.6 rhel jenkins images.  Thanks.

@bparees fyi

@tdawson @bparees As a side note, upstream jenkins appears to have started making changes wrt how plugn dependencies are loaded...let's not hold off on the items I noted above, but I'm going to investigate whether we can reduce the list of plugins we explicitly download / install.