### PR TITLE
reduce v2 plugin list, list parent plugins download

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -4,48 +4,17 @@ openshift-client:0.9.2
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
-durable-task:1.13
 kubernetes:0.10
-credentials:2.1.13
 
 # fabric8 openshift sync
 openshift-sync:0.1.11
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
-pipeline-build-step:2.1
-pipeline-graph-analysis:1.3
-pipeline-input-step:2.5
-pipeline-stage-step:2.2
 workflow-aggregator:2.1
-workflow-api:2.12
-workflow-basic-steps:2.3
-workflow-cps:2.29
-workflow-cps-global-lib:2.7
-workflow-durable-task-step:2.9
-workflow-job:2.10
-workflow-step-api:2.9
-workflow-support:2.13
 
-# Pipeline Multibranch Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Multibranch+Plugin
-workflow-multibranch:2.12
-cloudbees-folder:5.18
-
-# Pipeline stage view plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Stage+View+Plugin
-pipeline-stage-view:2.2
-handlebars:1.1.1
-pipeline-rest-api:2.2
-momentjs:1.1.1
 
 # remote loader https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin
 workflow-remote-loader:1.2
-scm-api:2.1.0
-branch-api:2.0.7
-
-# Pipeline SCM Step Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+SCM+Step+Plugin
-workflow-scm-step:2.4
-git:3.1.0
-mapdb-api:1.0.1.0
-subversion:2.5.7
 
 # mercurial - https://wiki.jenkins-ci.org/display/JENKINS/Mercurial+Plugin
 mercurial:1.54
@@ -55,15 +24,11 @@ ssh-credentials:1.12
 
 # Pipeline Utility Steps Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Utility+Steps+Plugin
 pipeline-utility-steps:1.1.5
-script-security:1.26
-
-# seem to be missing from the Jenkins docs but required to run these plugins..
-structs:1.6
-git-client:2.3.0
-git-server:1.6
-plain-credentials:1.3
-ace-editor:1.1
 
 # Jenkins v2 specific
 matrix-auth:1.4
 blueocean:1.0.0-b23
+
+# Legacy stuff
+mapdb-api:1.0.1.0
+subversion:2.5.7

--- a/2/test/run
+++ b/2/test/run
@@ -101,6 +101,23 @@ function test_get_job() {
   curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/job/$3
 }
 
+function test_non_pipeline_dependencies_pulled() {
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/ace-editor/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/branch-api/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/credentials/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/durable-task/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/cloudbees-folder/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/git-server/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/git-client/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/git/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/handlebars/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/momentjs/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/plain-credentials/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/scm-api/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/script-security/thirdPartyLicenses
+    curl --fail -u $1:$2 -X GET http://${CONTAINER_IP}:8080/pluginManager/plugin/structs/thirdPartyLicenses
+}
+
 function run_tests() {
   local name=$1 ; shift
   create_container $name $VOLUME
@@ -146,6 +163,7 @@ function run_tests() {
     return 1
   fi
   set -e
+  test_non_pipeline_dependencies_pulled admin newpassword
   # Stop the container so next tests can run
   docker stop $(get_cid $name)
 }


### PR DESCRIPTION
@tdawson @bparees the origin extended tests and jenkins v2 images test both look good.  I was also able to confirm from the make logs that the plugins removed from the list that we care about were in fact still downloaded (subversion wasn't but I was wondering if we really need that one)

When all is said and down then, I suspect the larger list for v1 jenkins will remain constant for plugins we don't own, while the smaller list of plugins we don't own for v2 can still change.  

Also, for @bparees and I, I believe this will shield from the scenario where a plugin changes dependency versions but the plugin itself does not change its version.  Since we are only including the "parent" plugins now.

I won't change the rhel Dockerfile until a) this PR merges, and b) we confirm with @tdawson that we have new RPMs for the remaining plugins (I *think* some of them have still changed with the recent PRs)

Even if the test passes, I won't merge until @bparees gets back from PTO and has a chance to digest this (and perhaps argues on inclusion of subversion)