### PR TITLE
Update Pipeline Groovy libraries

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -20,7 +20,7 @@ workflow-aggregator:2.1
 workflow-api:2.12
 workflow-basic-steps:2.3
 workflow-cps:2.29
-workflow-cps-global-lib:2.6
+workflow-cps-global-lib:2.7
 workflow-durable-task-step:2.9
 workflow-job:2.10
 workflow-step-api:2.9


### PR DESCRIPTION
I tried building this image from a dockerfile into OpenShift with the latest Jenkins image and received an error that the pipeline groovy libraries needed to be updated to 2.7.