### PR TITLE
Optionally install plugins on startup

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -103,6 +103,25 @@ if [ ! -e ${JENKINS_HOME}/configured ]; then
   cp -r /opt/openshift/configuration/* ${JENKINS_HOME}
   rm -rf /opt/openshift/configuration/*
 
+
+  # If the INSTALL_PLUGINS variable is populated, then attempt to install
+  # those plugins before copying them over to JENKINS_HOME
+  # The format of the INSTALL_PLUGINS variable is a comma-separated list
+  # of pluginId:pluginVersion strings
+  if [[ -n "${INSTALL_PLUGINS:-}" ]]; then
+    echo "Installing additional plugins: ${INSTALL_PLUGINS} ..."
+
+    # Create a temporary file in the format of plugins.txt
+    plugins_file=$(mktemp)
+    IFS=',' read -ra plugins <<< "${INSTALL_PLUGINS}"
+    for plugin in "${plugins[@]}"; do
+        echo "${plugin}" >> "${plugins_file}"
+    done
+
+    # Call install plugins with the temporary file
+    /usr/local/bin/install-plugins.sh "${plugins_file}"
+  fi
+
   if [ "$(ls -A /opt/openshift/plugins 2>/dev/null)" ]; then
     mkdir -p ${JENKINS_HOME}/plugins
     echo "Copying $(ls /opt/openshift/plugins | wc -l) Jenkins plugins to ${JENKINS_HOME} ..."

--- a/2/test/run
+++ b/2/test/run
@@ -201,6 +201,20 @@ function run_s2i_tests() {
     return 1
   fi
 
+  if [[ -n "{VERIFY_INSTALLED:-}" ]]; then
+	  if ! docker exec ${cid} ls /var/lib/jenkins/plugins/${VERIFY_INSTALLED}.jpi; then
+		  echo "Fail: the ${VERIFY_INSTALLED} plugin was not installed."
+		  return 1
+      fi
+  fi
+
+  if [[ -n "{VERIFY_NOT_INSTALLED:-}" ]]; then
+	  if docker exec ${cid} ls /var/lib/jenkins/plugins/${VERIFY_NOT_INSTALLED}.jpi; then
+		  echo "Fail: the ${VERIFY_NOT_INSTALLED} plugin was installed."
+		  return 1
+      fi
+  fi
+
   test_get_job admin password sample-app-test
   test_create_job admin password testJob
   test_get_job admin password testJob
@@ -210,15 +224,26 @@ function run_s2i_tests() {
 
 # Normal tests
 echo "Normal test: 64 bit"
+VERIFY_NOT_INSTALLED=ghprb
 CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=x86_64"
 run_tests jenkins_test
 cleanup
 sleep 5
 echo "Normal test: 32 bit"
 CIDFILE_DIR=$(mktemp --suffix=jenkins_test_cidfiles -d)
-VOLUME=`mktemp -d`
+VOLUME=$(mktemp -d)
 chmod a+rwx $VOLUME
 CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=i386 "
+run_tests jenkins_test
+cleanup
+sleep 5
+echo "Test: install plugins on start"
+CIDFILE_DIR=$(mktemp --suffix=jenkins_test_cidfiles -d)
+VOLUME=$(mktemp -d)
+chmod a+rwx $VOLUME
+VERIFY_INSTALLED=ghprb
+VERIFY_NOT_INSTALLED=""
+CONTAINER_ARGS="-u 10000:0 -e OPENSHIFT_JENKINS_JVM_ARCH=x86_64 -e INSTALL_PLUGINS=ghprb:1.35.0"
 run_tests jenkins_test
 
 # S2I tests

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 |  `JENKINS_PASSWORD`       | Password for the 'admin' account when using default Jenkin authentication.            |
 | `OPENSHIFT_ENABLE_OAUTH` | Determines whether the OpenShift Login plugin manages authentication when logging into Jenkins. |
 | `OPENSHIFT_PERMISSIONS_POLL_INTERVAL` | Specifies in milliseconds how often the OpenShift Login plugin polls OpenShift for the permissions associated with each user defined in Jenkins. |
+| `INSTALL_PLUGINS`         | Comma-separated list of additional plugins to install on startup. The format of each plugin spec is `plugin-id:version` (as in plugins.txt) |
 
 
 
@@ -143,6 +144,17 @@ $ s2i build https://github.com/your/repository openshift/jenkins-1-centos7 your_
 ```
 NOTE:  if instead of adding a plugin you want to replace an existing plugin via dropping the binary plugin in the `./plugins` directory,
 make sure the filename ends in `.jpi`.
+
+####  Installing on Startup
+
+The INSTALL_PLUGINS environment variable may be used to install a set of plugins on startup. When using a
+persistent volume for /var/lib/jenkins, plugin installation will only happen on the initial run of the image.
+
+In the following example, the Groovy and Pull Request Builder plugins are installed
+
+```
+INSTALL_PLUGINS=groovy:1.30,ghprb:1.35.0
+```
 
 #### Plugins of note
 


### PR DESCRIPTION
Add support for an environment variable (INSTALL_PLUGINS) that allows
installing a set of plugins on image startup. The format of the variable
is a set of comma-separated strings of the form [plugin-id]:[version].
Example:
INSTALL_PLUGINS=groovy:1.30,github-pr-comment-build:1.1

When used with persistent storage, plugin download/installation would
only happen the very first time the image is run.