### PR TITLE
Consistent naming for Docker images built

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -12,8 +12,7 @@ OS=$1
 VERSION=$2
 
 DOCKERFILE_PATH=""
-BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-.*$//g')
-BASE_IMAGE_NAME="openshift/${BASE_DIR_NAME#s2i-}"
+BASE_IMAGE_NAME="openshift/jenkins"
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT


### PR DESCRIPTION
I was having problems building the Docker image.

Here is how I tried:

```
$ git clone git@github.com:openshift/jenkins.git openshift-jenkins
    Cloning into 'openshift-jenkins'...
    .......
    Resolving deltas: 100% (786/786), done.

$ cd openshift-jenkins

$ docker images
    <NOTHING>

$ make build TARGET=centos7 VERSION=2
    .......
    .......
    Successfully built 22ba8f27048c

$ docker images
    openshift/openshift-2-centos7      latest              22ba8f27048c        24 seconds ago      1.25 GB
```

`build.sh` script is doing some magic based on the directory name. However, the target image will have a weird name if the sources are checked out in a directory named differently.

Following works (when I don't specify the clone target dir):

```
$ git clone git@github.com:openshift/jenkins.git
    Cloning into 'jenkins'...
    .......
    Resolving deltas: 100% (786/786), done.

$ cd jenkins

$ docker images
    <NOTHING>

$ make build TARGET=centos7 VERSION=2
    .......
    .......
    Successfully built 85adbe9718ae

$ docker images
    openshift/jenkins-2-centos7        latest              85adbe9718ae        43 seconds ago      1.25 GB
```


With the PR, I got rid of the part where `build.sh` is trying to do the magic and building the image name based on that.
I can see that build.sh is only used in `Makefile` and my change will result in consistency.

With the PR, doing the first operation above will result in `openshift/jenkins-2-centos7` no matter what the directory is.

I was trying to understand why there is such a logic, but I couldn't.


