### PR TITLE
bump pipeline-model-def to account for cloudbees plugin name change

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -34,4 +34,4 @@ mapdb-api:1.0.1.0
 subversion:2.5.7
 
 # Declarative Pipeline
-pipeline-model-definition:1.1.1
+pipeline-model-definition:1.1.4


### PR DESCRIPTION
pipeline-model-definition dependency download was failing because of cloudbees plugin name change ... ref:  https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Workflow+Plugin

@bparees @oatmealraisin @tdawson FYI