### PR TITLE
bump sync to 0.1.14

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.13
+openshift-sync:0.1.14
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:0.9.3
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.13
+openshift-sync:0.1.14
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 workflow-aggregator:2.1


### PR DESCRIPTION
@bparees @tdawson FYI

@jim-minter - this will pull into the openshift jenkins centos image the sync plugin change to be more prudent on when bc's are updated 