### PR TITLE
bump openshift plugins for various fixes

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
-openshift-pipeline:1.0.42
+openshift-pipeline:1.0.45
 openshift-login:0.12
-openshift-client:0.9.3
+openshift-client:0.9.4
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.14
+openshift-sync:0.1.16
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,13 +1,13 @@
-openshift-pipeline:1.0.42
+openshift-pipeline:1.0.45
 openshift-login:0.12
-openshift-client:0.9.3
+openshift-client:0.9.4
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.14
+openshift-sync:0.1.16
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 workflow-aggregator:2.1


### PR DESCRIPTION
@openshift/devex FYI

@smunilla ptal - we'll need new 3.6 based RPMs built for these new versions of the openshift pipeline, client, and sync plugins