### PR TITLE
bump sync plugin to 0.1.24

### DIFF
--- a/1/contrib/openshift/base-plugins.txt
+++ b/1/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ kubernetes:0.10
 credentials:2.1.9
 
 # fabric8 openshift sync
-openshift-sync:0.1.23
+openshift-sync:0.1.24
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 pipeline-build-step:2.1

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:0.9.6
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.23
+openshift-sync:0.1.24
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)


### PR DESCRIPTION
v0.1.24 of the sync plugin brings in the setting of user-agent of the underlying http client that came out of the recent diagnosis for the us-east prod cluster struggles

@bparees - I'm assuming we want this in 3.6 - that your opinion?

@bparees @jupierce @smunilla - if so, we need to build a 3.6 rpm and a new 3.6 jenkins image, and presumably consider whether the resulting image is what goes into the pipeline for the upcoming upgrade of the jenkins image running in us-prod east .... what is everyone thoughts?