### PR TITLE
bump sync to 0.1.25 for bugzillas

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:0.9.6
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.24
+openshift-sync:0.1.25
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)


### PR DESCRIPTION
for https://bugzilla.redhat.com/show_bug.cgi?id=1473329 and https://bugzilla.redhat.com/show_bug.cgi?id=1475867

@bparees with v1 deprecated in 3.6, should we continue to bump our plugins in the v1 image (this PR does not currently)

@smunilla @jupierce - don't know if the 3.6 release coming out means for your immediate workload, but both a customer and the online tier will want the RPM update for sync plugin minimally as part of post 3.6.  The specifics should be tracked in the bugzillas.  Thanks.