### PR TITLE
include hidden files when copying and moving in s2i/run

### DIFF
--- a/2/contrib/s2i/assemble
+++ b/2/contrib/s2i/assemble
@@ -3,6 +3,8 @@
 JENKINS_DIR=/opt/openshift
 JENKINS_INSTALL_DIR=$(mktemp -d --suffix=jenkins)
 
+shopt -s dotglob
+
 echo "---> Copying repository files ..."
 cp -Rf /tmp/src/. ${JENKINS_INSTALL_DIR}
 
@@ -31,6 +33,5 @@ if [ -d ${JENKINS_INSTALL_DIR}/configuration ]; then
   fi
   echo "---> Installing new Jenkins configuration ..."
   /usr/local/bin/fix-permissions ${JENKINS_INSTALL_DIR}/configuration
-  shopt -s dotglob
   mv ${JENKINS_INSTALL_DIR}/configuration/* ${JENKINS_DIR}/configuration/
 fi

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -9,6 +9,8 @@
 source /usr/local/bin/jenkins-common.sh
 source /usr/local/bin/kube-slave-common.sh
 
+shopt -s dotglob
+
 function update_admin_password() {
     sed -i "s,<passwordHash>.*</passwordHash>,<passwordHash>$new_password_hash</passwordHash>,g" "${JENKINS_HOME}/users/admin/config.xml"
     echo $new_password_hash > ${JENKINS_HOME}/password


### PR DESCRIPTION
I've added "shopt -s dotglob" in s2i/run as well, such that e.g. ${JENKINS_INSTALL_DIR}/configuration/.gitconfig file will be copied as well.

Furthermore, I moved the "shopt -s dotglob" command in s2i/assemble to the top, since it changes the global state of the bash process and should not be hidden in the code. As a consequence, hidden files from ${JENKINS_INSTALL_DIR}/plugins will also be copied, but I can't think of any harm there.