### PR TITLE
bump sync plugin to 0.1.29

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:0.9.6
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.28
+openshift-sync:0.1.29
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)


### PR DESCRIPTION
pulls in some fixes for @csrwng and @scoheb 

@openshift/devex fyi

@jupierce I'll post when the test job completes the latest plugin list that gets dumped by our test job for jenkins rhel image updating