### PR TITLE
bump sync for openshift/origin field selector workaround

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:0.9.6
 kubernetes:0.10
 
 # fabric8 openshift sync
-openshift-sync:0.1.29
+openshift-sync:0.1.30
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)


### PR DESCRIPTION
downgrading fabric8 for now until a 3.6.1 and later 3.7.0-alpha are cut to include fix for issue seen in https://github.com/openshift/origin/issues/16501 and https://github.com/openshift/jenkins-sync-plugin/issues/173