### PR TITLE
bump client plugin to 1.0.0 as part of GA in 3.7

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
 openshift-pipeline:1.0.52
 openshift-login:0.12
-openshift-client:0.9.6
+openshift-client:1.0.0
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
pulling in a minor refinement to the client plugin, then officially moving to 1.0.0 as part of this no longer being experimental in 3.7

@openshift/devex @jupierce FYI