### PR TITLE
clean up dos file carriage returns

### DIFF
--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -338,6 +338,11 @@ main() {
 
     mkdir -p "$REF_DIR" || exit 1
 
+    for file in $@; do
+	# clean up any dos file injected carriage returns
+	sed -i 's/\r$//' $file
+    done
+
     # Create lockfile manually before first run to make sure any explicit version set is used.
     echo "Creating initial locks..."
     for plugin in `cat $@ | grep -v ^#`; do


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins/issues/390

@openshift/devex fyi

thx for the `bash` assist @bparees 

validated with both dos and unix files

`dos2unix` was not available in the openshift/origin image