### PR TITLE
Fix OpenJDK default settings so as to use less memory.

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -138,8 +138,9 @@ if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
 fi
 
 if [ -z "$JAVA_GC_OPTS" ]; then
-  # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
+    # We no longer set MaxMetaspaceSize because the JVM should expand metaspace until it reaches the container limit.
+    # See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/4dd24f4ca140/src/share/vm/memory/metaspace.cpp#l1470
+    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 fi
 
 if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then
@@ -150,8 +151,8 @@ if [ ! -z "${CONTAINER_CORE_LIMIT}" ]; then
     JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMT} -XX:CICompilerCount=2"
 fi
 
-if [ -z "${JVM_ARGS}" ]; then
-    JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+if [ -z "${JAVA_OPTS}" ]; then
+    JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
 fi
 
 # Since OpenShift runs this Docker image under random user ID, we have to assign
@@ -227,7 +228,7 @@ fi
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -131,17 +131,15 @@ if [ "${CONTAINER_MEMORY_IN_BYTES}" -lt "${DEFAULT_MEMORY_CEILING}" ]; then
 
     JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
     if [ -z $CONTAINER_INITIAL_PERCENT ]; then
-      # jboss default was 100% or ms==mx
-      JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_HEAP_MAX}m"
-    else
-      CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
-      JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
+      CONTAINER_INITIAL_PERCENT=0.07
     fi
+    CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
 fi
 
 if [ -z "$JAVA_GC_OPTS" ]; then
   # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
-  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
+  JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
 fi
 
 if [ ! -z "${USE_JAVA_DIAGNOSTICS}" ]; then
@@ -225,7 +223,7 @@ fi
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dsun.zip.disableMemoryMapping=true -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -150,6 +150,10 @@ if [ ! -z "${CONTAINER_CORE_LIMIT}" ]; then
     JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMT} -XX:CICompilerCount=2"
 fi
 
+if [ -z "${JVM_ARGS}" ]; then
+    JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+fi
+
 # Since OpenShift runs this Docker image under random user ID, we have to assign
 # the 'jenkins' user name to this UID.
 generate_passwd_file
@@ -223,7 +227,7 @@ fi
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dsun.zip.disableMemoryMapping=true -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -87,16 +87,15 @@ if [[ $# -gt 1 ]]; then
 
     JAVA_MAX_HEAP_PARAM="-Xmx${CONTAINER_HEAP_MAX}m"
     if [ -z $CONTAINER_INITIAL_PERCENT ]; then
-      # jboss default was 100% or ms==mx
-      JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_HEAP_MAX}m"
-    else
-      CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
-      JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
+      CONTAINER_INITIAL_PERCENT=0.07
     fi
+    CONTAINER_INITIAL_HEAP=$(echo "${CONTAINER_HEAP_MAX} ${CONTAINER_INITIAL_PERCENT}" | awk '{ printf "%d", $1 * $2 }')
+    JAVA_INITIAL_HEAP_PARAM="-Xms${CONTAINER_INITIAL_HEAP}m"
   fi
 
   if [ -z $JAVA_GC_OPTS ]; then
-    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MaxPermSize=100m -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
+    # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
+    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
   fi
 
 
@@ -108,8 +107,12 @@ if [[ $# -gt 1 ]]; then
       JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMIT} -XX:CICompilerCount=2"
   fi
 
-  echo Running java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"
-  cd ${JENKINS_DIR} && exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM  \
+  if [ -z "${JVM_ARGS}" ]; then
+      JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+  fi
+
+  echo Running java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"
+  cd ${JENKINS_DIR} && exec java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM  \
                                  $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS \
                                  $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main \
                                  -headless $PARAMS "$@"

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -94,8 +94,9 @@ if [[ $# -gt 1 ]]; then
   fi
 
   if [ -z $JAVA_GC_OPTS ]; then
-    # note - MaxPermSize no longer valid with v8 of the jdk ... used to have -XX:MaxPermSize=100m
-    JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m"
+      # We no longer set MaxMetaspaceSize because the JVM should expand metaspace until it reaches the container limit.
+      # See http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/4dd24f4ca140/src/share/vm/memory/metaspace.cpp#l1470
+      JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
   fi
 
 
@@ -107,12 +108,12 @@ if [[ $# -gt 1 ]]; then
       JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMIT} -XX:CICompilerCount=2"
   fi
 
-  if [ -z "${JVM_ARGS}" ]; then
-      JVM_ARGS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+  if [ -z "${JAVA_OPTS}" ]; then
+      JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
   fi
 
-  echo Running java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"
-  cd ${JENKINS_DIR} && exec java $JVM_ARGS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM  \
+  echo Running java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"
+  cd ${JENKINS_DIR} && exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM  \
                                  $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS \
                                  $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main \
                                  -headless $PARAMS "$@"


### PR DESCRIPTION
- Set CONTAINER_INITIAL_PERCENT to something small by
  default, rather than 100%. Setting it to 100% results in `-Xms==-Xmx`
  which is bad as it tells the GC that it's fine to use at least the max amount.
  Thus it'll never attempt to return pages to the OS which it would otherwise do when
  `-Xms` is set to something small. That's memory other containers could use.
- Use `-Dsun.zip.disableMemoryMapping=true` as this saves some percent
  on memory. The added (performance) cost for class loading is negligible.
- Set `-XX:MinHeapFreeRatio` and `-XX:MaxHeapFreeRatio` to more aggressive values. This together with a low -Xms will make the GC do the right thing.
- Set `-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap` unconditionally
  as this tells the JVM that physical memory is determined by the cgroup limit (not just the heap). There are some off-heap structures which might get sized wrongly without that option.

This saves about 29% of used VmRSS over the old config for my testing. `388MB` on average for the old settings. `274MB` on average for the new settings. See:
![jenkins_plain_old_vs_new](https://user-images.githubusercontent.com/357222/31439982-9039054c-ae8e-11e7-8df5-ead062dd97cb.png)

The old settings produced this java command in the container:

    $ java -XX:+UseParallelGC -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m -Xms256m -Xmx256m -Duser.home=/var/lib/jenkins -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war

The new settings produce this java command in the container:

     $ java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:MaxMetaspaceSize=100m -Xms17m -Xmx256m -Duser.home=/var/lib/jenkins -Dsun.zip.disableMemoryMapping=true -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war

fixes https://github.com/openshift/jenkins/issues/411
