### PR TITLE
bump sync to 0.1.32

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:1.0.0
 kubernetes:1.0
 
 # fabric8 openshift sync
-openshift-sync:0.1.31
+openshift-sync:0.1.32
 
 # Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)


### PR DESCRIPTION
pulling in recent fixes we've targeted for 3.7

going to let an overnight test run or two go green prior to requesting plugin / image update for rhel