### PR TITLE
Improve support for Jenkins monitoring plugin

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -223,6 +223,14 @@ if [ ! -z "${OPENSHIFT_USE_ACCESS_LOG}" ]; then
     JENKINS_ACCESSLOG="--accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/jenkins/access_log"
 fi
 
+## The Jenkins monitoring plugin stores its data in /var/lib/jenkins/monitoring/<hostName>.
+## Since the pod name changes everytime there is a deployment, any trending data is lost over
+## re-deployments. We force the application name to allow for historical data collection.
+##
+JENKINS_SERVICE_NAME=${JENKINS_SERVICE_NAME:-JENKINS}
+JENKINS_SERVICE_NAME=`echo ${JENKINS_SERVICE_NAME} | tr '[a-z]' '[A-Z]' | tr '-' '_'`
+JAVA_OPTS="${JAVA_OPTS} -Djavamelody.application-name=${JENKINS_SERVICE_NAME}"
+
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
    exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"


### PR DESCRIPTION
The Jenkins monitoring plugin stores its data in /var/lib/jenkins/monitoring/<hostName>.
Since the pod name changes everytime there is a deployment, any trending data is lost over
re-deployments. We force the application name to allow for historical data collection.