### PR TITLE
[WIP] Export JAVA_OPTS and MAVEN_OPTS

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -153,6 +153,12 @@ fi
 
 if [ -z "${JAVA_OPTS}" ]; then
     JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+    export JAVA_OPTS
+fi
+
+if [ -z "${MAVEN_OPTS}" ]; then
+    MAVEN_OPTS="${JAVA_OPTS}"
+    export MAVEN_OPTS
 fi
 
 # Since OpenShift runs this Docker image under random user ID, we have to assign
@@ -232,11 +238,10 @@ fi
 ##
 JENKINS_SERVICE_NAME=${JENKINS_SERVICE_NAME:-JENKINS}
 JENKINS_SERVICE_NAME=`echo ${JENKINS_SERVICE_NAME} | tr '[a-z]' '[A-Z]' | tr '-' '_'`
-JAVA_OPTS="${JAVA_OPTS} -Djavamelody.application-name=${JENKINS_SERVICE_NAME}"
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-   exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
+   exec java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM -Duser.home=${HOME} $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -Djavamelody.application-name=${JENKINS_SERVICE_NAME} -Dfile.encoding=UTF8 -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS $JENKINS_ACCESSLOG "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -110,6 +110,12 @@ if [[ $# -gt 1 ]]; then
 
   if [ -z "${JAVA_OPTS}" ]; then
       JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+      export JAVA_OPTS
+  fi
+
+  if [ -z "${MAVEN_OPTS}" ]; then
+      MAVEN_OPTS="${JAVA_OPTS}"
+      export MAVEN_OPTS
   fi
 
   echo Running java $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS $JAVA_OPTS -cp $JAR hudson.remoting.jnlp.Main -headless $PARAMS "$@"


### PR DESCRIPTION
If not in the environment already, export JAVA_OPTS and MAVEN_OPTS with options
that ensure that the JVM respects the cgroup memory size for its heap
calculations.