### PR TITLE
Upgrade Node.js slave to Node.js 8

### DIFF
--- a/slave-nodejs/Dockerfile
+++ b/slave-nodejs/Dockerfile
@@ -2,7 +2,7 @@ FROM openshift/jenkins-slave-base-centos7
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 
-ENV NODEJS_VERSION=4.4 \
+ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \
@@ -13,7 +13,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install NodeJS
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/slave-nodejs/Dockerfile.rhel7
+++ b/slave-nodejs/Dockerfile.rhel7
@@ -7,12 +7,12 @@ LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-docker" \
       name="openshift3/jenkins-slave-nodejs-rhel7" \
       version="3.6" \
       architecture="x86_64" \
-      release="4" \
+      release="5" \
       io.k8s.display-name="Jenkins Slave Nodejs" \
       io.k8s.description="The jenkins slave nodejs image has the nodejs tools on top of the jenkins slave base image." \
       io.openshift.tags="openshift,jenkins,slave,nodejs"
 
-ENV NODEJS_VERSION=4.4 \
+ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \
@@ -25,7 +25,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \    
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-nodejs-nodemon" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/slave-nodejs/contrib/bin/scl_enable
+++ b/slave-nodejs/contrib/bin/scl_enable
@@ -1,3 +1,3 @@
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-nodejs4
+source scl_source enable rh-nodejs8


### PR DESCRIPTION
This is mainly just an observation that the current Node.js 4 that's
referenced in these Dockerfiles is quite old at this point. While it's
still maintained, it's in the 'Maintenance' phase of its LTS cycle,
and will be EOL in April 2018:

https://github.com/nodejs/Release#lts-schedule

I was originally going to propose Node.js 6 here, but given that
Node.js 8 is the most recent active LTS, this proposes to go straight
to that.

I've successfully built the CentOS image from this commit locally, but
I haven't done any extensive testing on it -- I wanted to first see if
this is a change that you actually want.


I tried building from the Dockerfile.rhel7 image inside a CDK
minishift VM, but it couldn't find the rh-nodejs8* packages, even
though there's a RHEL7 Dockerfile that appears to use them at [1], and
I see a nodejs-8-rhel7 image on the Red Hat Container Catalog[2].

[1] https://github.com/sclorg/s2i-nodejs-container/blob/master/8/Dockerfile.rhel7
[2] https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-8-rhel7