### PR TITLE
bump kubernetes plugin to 1.1

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -4,7 +4,7 @@ openshift-client:1.0.2
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
-kubernetes:1.0
+kubernetes:1.1
 
 # fabric8 openshift sync
 openshift-sync:0.1.32


### PR DESCRIPTION
* Bump kubernetes plugin to 1.1. Adds possibility to specify activeDeadlineSeconds to Pods so that slaves that Jenkins starts eats the correct quota from openshift, given that you have specified quota for time bound pods.