### PR TITLE
Make plugin download timeouts configurable

### DIFF
--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -203,7 +203,7 @@ function doDownload() {
     url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"
 
     echo "Downloading plugin: $plugin from $url"
-    curl --connect-timeout 5 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L "$url" -o "$jpi"
+    curl --connect-timeout "${CURL_CONNECTION_TIMEOUT:-20}" --retry "${CURL_RETRY:-5}" --retry-delay "${CURL_RETRY_DELAY:-0}" --retry-max-time "${CURL_RETRY_MAX_TIME:-60}" -s -f -L "$url" -o "$jpi"
     return $?
 }
 


### PR DESCRIPTION
The default timeout of 5 seconds for downloading plugins are to narrow for us.
This PR increases the curl connection timeout from 5 to 20 seconds. This follows the original [install-plugins-sh](https://github.com/jenkinsci/docker/commit/21b0f37a8b2d4dfa359cfa87eb849531ff5a9290) from the [official jenkins docker image](https://github.com/jenkinsci/docker)

At the same time make it possible to configure the timeouts for plugin downloads, which also reflects the script from the original jenkins docker image. See [install-plugins.sh#L78](https://github.com/jenkinsci/docker/blob/master/install-plugins.sh#L78)