### PR TITLE
perform update center syncrhonization during startup instead of first login

### DIFF
--- a/2/contrib/openshift/configuration/init.groovy.d/init.groovy
+++ b/2/contrib/openshift/configuration/init.groovy.d/init.groovy
@@ -1,0 +1,3 @@
+import jenkins.model.Jenkins
+Jenkins.getInstance().getPluginManager().doCheckUpdatesServer()
+Jenkins.getInstance().getUpdateCenter().getCoreSource().getData()

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -80,7 +80,7 @@ func (j *Jenkins) Start(image string, env []string) error {
 }
 
 func (j *Jenkins) wait() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	for {


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

I've observed within the last few weeks and inordinate delay the very first time you login to a jenkins instance instantiated from our image, often resulting in a 504 / gateway timeout

In conjunction, I observer a lengthy CPU burn with the jenkins process.  And it occurred across different permutations (i.e. both with oauth on and off, no openshift pod, etc.)

Thread dumps during the CPU burn revealed that the administrative alerts were being accessed on the login threads, and the jenkins core update / security alert monitors were taking forever, downloading/parsing their json data.  

UPDATE March 5 2018:
Instead of the monitor disablement below, we were able to move the processing to jenkins startup via an init groovy scrip
END UPDATE

I suspect a recent jenkins LTS upgrade coupled with the pipeline plugin list growing in complexity has lead to this.  In typical, centralized, long running jenkins deployments, I suspect this isn't a huge deal.

The only viable workaround I could conjure was to disable those two monitors on startup.

Of course the user can re-enable as they desire.

Per discussion with @bparees, the core update monitor is more or less orthogonal to our scenario since any jenkins core update would be best proscribed via an image regen.

For the security alert (basically those warnings when they publish an plugin update for a discovered security hole), there are other means of getting pushed notified via mailing lists.  But perhaps this is more arguable.