### PR TITLE
add version tags to Dockerfiles

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin
+FROM openshift/origin:v3.7.0
 
 # Jenkins image for OpenShift
 #

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin
+FROM openshift/origin:v3.7.0
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 


### PR DESCRIPTION
Adds version tags to parent docker images so that at least `oc` will be stable instead of latest alpha version. 

Fixes #446