### PR TITLE
Update credentials-binding plugin

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -23,6 +23,8 @@ mercurial:1.54
 matrix-project:1.7.1
 multiple-scms:0.6
 ssh-credentials:1.13
+credentials-binding:1.13
+
 
 # Pipeline Utility Steps Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Utility+Steps+Plugin
 pipeline-utility-steps:1.5.1
@@ -40,7 +42,7 @@ mapdb-api:1.0.1.0
 subversion:2.9
 
 # explicitly pull in plugins previously pulled in by dependencies because of
-# security advisories  ...exclude plugins from 
+# security advisories  ...exclude plugins from
 # advisories that were not previously pulled in by what is listed above
 # also, as the plugins above raise their dependency levels for these plugins let's see about removing
 # items from the list below


### PR DESCRIPTION
When using `withCredentials` with v1.12 of the credentials-binding
plugin causes the console output to become corrupted with extra
asterisks making output difficult to read.  This is also described in [JENKINS-41760](https://issues.jenkins-ci.org/browse/JENKINS-41760)