### PR TITLE
use v3.7 release tagged base image

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin
+FROM openshift/origin:v3.7.0
 
 # Jenkins image for OpenShift
 #

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin
+FROM openshift/origin:v3.7.0
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 


### PR DESCRIPTION
note that i'm intentionally not doing this for the rhel images.  it would require changes to our CI jobs that aren't worth doing since the rhel-built images produced from this repo aren't what we ship anyway.

fixes https://github.com/openshift/jenkins/issues/456
