### PR TITLE
🔒 Update to latest script-security for advisory

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -64,6 +64,4 @@ parameterized-trigger:2.35.1
 pipeline-build-step:2.5.1
 pipeline-input-step:2.8
 workflow-cps:2.39
-script-security:1.31
-
-
+script-security:1.39


### PR DESCRIPTION
The changelog for this plugin can be seen here:
https://plugins.jenkins.io/script-security

The following advisory was addressed in version 1.37:
https://jenkins.io/security/advisory/2017-12-11/