### PR TITLE
add variable for additional Java user options

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -326,6 +326,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   set -x
   exec java $JENKINS_JAVA_OPTIONS -Duser.home=${HOME} \
             -Djavamelody.application-name=${JENKINS_SERVICE_NAME} \
+            $JENKINS_JAVA_OVERRIDES \
             -jar /usr/lib/jenkins/jenkins.war $JENKINS_OPTS "$@"
 fi
 


### PR DESCRIPTION
Added a new variable so it's possible to pass additional Java options to Jenkins, like those [useful for the Kubernetes plugin](https://github.com/jenkinsci/kubernetes-plugin#over-provisioning-flags) without disturbing or redefining other Java flags.