### PR TITLE
bump login plugin for bearer token after restart fix

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.47
-openshift-login:0.12
+openshift-login:1.0.3
 openshift-client:0.9.6
 
 


### PR DESCRIPTION
for https://bugzilla.redhat.com/show_bug.cgi?id=1533938

@bparees @jupierce @adammhaile fyi - will propose to support / customer that this will go out with the next errata; hopefully that is sufficient, along with downloading the plugin from the jenkins update center, vs. a hot fix