### PR TITLE
bump login plugin for bearer token after restart fix

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-pipeline:1.0.52
-openshift-login:1.0.0
+openshift-login:1.0.3
 openshift-client:1.0.2
 
 


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1533938

@bparees - figured will update 3.7 as well while we are at it (even though the customer in the bugzilla is at 3.5/3.6)