### PR TITLE
bump blueocean; clean up stale security adv bumps

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -9,11 +9,26 @@ kubernetes:1.1.3
 # fabric8 openshift sync
 openshift-sync:0.9.2
 
-# Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
-# 2.5 now includes pipeline-model-definition (declaritive pipeline)
-# 2.4 brought in pipeline-milestone-step
-workflow-aggregator:2.5
+# explicitly pull in plugins previously pulled in by dependencies because of
+# security advisories  ...exclude plugins from
+# advisories that were not previously pulled in by what is listed above
+# also, as the plugins above raise their dependency levels for these plugins let's see about removing
+# items from the list below
+#
+# processed sec adv https://jenkins.io/blog/2017/07/10/security-advisory/
+# processed sec adv https://jenkins.io/security/advisory/2017-08-07/
+#
+config-file-provider:2.16.2
+docker-commons:1.8
+job-dsl:1.60
+parameterized-trigger:2.35.1
+pipeline-build-step:2.5.1
+pipeline-input-step:2.8
+script-security:1.39
 
+# Legacy stuff
+mapdb-api:1.0.1.0
+subversion:2.9
 
 # remote loader https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Remote+Loader+Plugin
 workflow-remote-loader:1.2
@@ -38,29 +53,10 @@ github-organization-folder:1.6
 
 # Jenkins v2 specific
 matrix-auth:1.5
-blueocean:1.1.6
+blueocean:1.4.0
 
-# Legacy stuff
-mapdb-api:1.0.1.0
-subversion:2.9
+# Pipeline plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin
+# 2.5 now includes pipeline-model-definition (declaritive pipeline)
+# 2.4 brought in pipeline-milestone-step
+workflow-aggregator:2.5
 
-# explicitly pull in plugins previously pulled in by dependencies because of
-# security advisories  ...exclude plugins from
-# advisories that were not previously pulled in by what is listed above
-# also, as the plugins above raise their dependency levels for these plugins let's see about removing
-# items from the list below
-#
-# processed sec adv https://jenkins.io/blog/2017/07/10/security-advisory/
-# processed sec adv https://jenkins.io/security/advisory/2017-08-07/
-#
-config-file-provider:2.16.2
-docker-commons:1.8
-git:3.3.2
-git-client:2.4.4
-github-branch-source:2.0.8
-job-dsl:1.60
-parameterized-trigger:2.35.1
-pipeline-build-step:2.5.1
-pipeline-input-step:2.8
-workflow-cps:2.39
-script-security:1.39


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins/issues/428

@openshift/sig-developer-experience fyi

in addition to bumping blue ocean, it removes plugin versions from our security advisory list that are now getting pulled by the pipeline/workflow plugin aggregator

also, moving the pipeline / workflow aggregator to the end helped with bumping the version of security advisory plugins if those plugins were optional plugins for pipeline / workflow