### PR TITLE
pull in 3.7 9b5f7bf 7ef705b 9db8ae2

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -51,9 +51,11 @@ ADD ./contrib/s2i /usr/libexec/s2i
 # and its presence in the rhel image is confusing.
 RUN rm /opt/openshift/base-plugins.txt && \ 
     mkdir -p /opt/openshift/plugins && \
-    # NOTE: When adding new Jenkins plugin, you have to create the symlink for the
-    # HPI file created by rpm to /opt/openshift/plugins folder.
-    for FILENAME in /usr/lib64/jenkins/*hpi ; do ln -s $FILENAME /opt/openshift/plugins/`basename $FILENAME .hpi`.jpi; done &&\
+    # we symlink the rpm installed plugins from /usr/lib/jenkins to /opt/openshift/plugins so that
+    # future upgrades of the image and their RPM install automatically get picked by jenkins;
+    # we use symlinks vs. actual files to delineate whether the user has overridden a plugin (and
+    # by extension taken over its future maintenance)
+    for FILENAME in /usr/lib/jenkins/*hpi ; do ln -s $FILENAME /opt/openshift/plugins/`basename $FILENAME .hpi`.jpi; done &&\
     chmod 775 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
@@ -91,7 +93,7 @@ RUN rm /opt/openshift/base-plugins.txt && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     chown -R 1001:0 /opt/openshift && \
     # the prior chown doesn't traverse the /opt/openshift/plugins links .. this one will assist fix-permission/assemble for extension builds like master/slave
-    chown 1001:0 /usr/lib64/jenkins/*hpi && \ 
+    chown 1001:0 /usr/lib/jenkins/*hpi && \ 
     /usr/local/bin/fix-permissions /var/lib/jenkins && \
     /usr/local/bin/fix-permissions /var/log
 

--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -114,7 +114,8 @@ copy_reference_file() {
             action=${action:-"INSTALLED"}
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -r "${f}" "$JENKINS_HOME/${rel}";
+	    # if done on rhel, we may need to override a link to /usr/lib/jenkins, so include --remove-destination
+            cp --remove-destination -r "${f}" "$JENKINS_HOME/${rel}";
             # pin plugins on initial copy
             touch "$JENKINS_HOME/${rel}.pinned"
             echo "$image_version" > "$JENKINS_HOME/${version_marker}"
@@ -128,7 +129,8 @@ copy_reference_file() {
             action="INSTALLED"
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -r "${f}" "$JENKINS_HOME/${rel}";
+	    # if done on rhel, we may need to override a link to /usr/lib/jenkins, so include --remove-destination
+            cp --remove-destination -r "${f}" "$JENKINS_HOME/${rel}";
         else
             action="SKIPPED"
         fi

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -90,6 +90,49 @@ new_password_hash=`obfuscate_password ${JENKINS_PASSWORD:-password} $old_salt`
 mkdir ${JENKINS_HOME}/logs
 ln -sf ${JENKINS_HOME}/logs /var/log/jenkins
 
+# clean up any plugins in JENKINS_HOME/plugins which we previously linked, but
+# have since deleted from the image
+for FILENAME in ${JENKINS_HOME}/plugins/*.jpi; do
+    # test if it is a sym link, otherwise users have overriden, so leave alone
+    # test command silent, don't need dev/null
+    test -h $FILENAME
+    if [ $? -eq 0 ]; then
+	stat -L $FILENAME >& /dev/null
+	if [ $? -eq 0 ]; then
+	    continue
+	fi
+	echo "Unlinking plugin ${FILENAME} since it has been removed"
+	unlink $FILENAME
+    fi
+done
+
+# for rhel, while the plugins are initially linked to the image volume on initial start,
+# some maintenance wrt transferring plugins is done on every startup;  this logic
+# covers the case of a release upgrade that introduces new plugins.
+#
+# we employ links instead of copies, and check for the existance in JENKINS_HOME/plugins,
+# so that:
+# 1) we don't copy over plugins the user has overridden since this image first was started
+# (either via this image's extension mechanisms or the jenkins plugin mgr console)
+# 2) if versions of an existing plugin change as a result of a release upgrade, those changes
+# are picked up
+#
+# all of this is moot on centos, since our centos image does not store any plugins in /usr/lib/jenkins
+if [ "$(ls /usr/lib/jenkins/*.hpi 2>/dev/null)" ]; then
+    # in case very first time through, make sure plugins dir is there
+    mkdir -p ${JENKINS_HOME}/plugins
+   
+   for FILENAME in /usr/lib/jenkins/*.hpi ; do
+        basefilename=`basename $FILENAME .hpi`
+        plugin_image_volume_location="${JENKINS_HOME}/plugins/${basefilename}.*"
+        if [ "$(ls ${plugin_image_volume_location} 2>/dev/null)" ]; then
+          continue
+        fi
+	echo "Linking ${FILENAME} RPM installed Jenkins plugins to ${JENKINS_HOME} ..."  
+        ln -s  $FILENAME ${JENKINS_HOME}/plugins/${basefilename}.jpi
+   done
+fi
+
 if [ ! -e ${JENKINS_HOME}/configured ]; then
   # This container hasn't been configured yet, so copy the default configuration from
   # the image into the jenkins config path (which should be a volume for persistence).
@@ -138,10 +181,15 @@ if [ ! -e ${JENKINS_HOME}/configured ]; then
     /usr/local/bin/install-plugins.sh "${plugins_file}"
   fi
 
-  if [ "$(ls -A /opt/openshift/plugins 2>/dev/null)" ]; then
+  if [ "$(ls /opt/openshift/plugins/* 2>/dev/null)" ]; then
     mkdir -p ${JENKINS_HOME}/plugins
-    echo "Copying $(ls /opt/openshift/plugins | wc -l) Jenkins plugins to ${JENKINS_HOME} ..."
-    cp -r /opt/openshift/plugins/* ${JENKINS_HOME}/plugins/
+    echo "Copying $(ls /opt/openshift/plugins/* | wc -l) files to ${JENKINS_HOME} ..."
+    # in case of rhel, if there are plugins in /opt/openshift/plugins, that means the user is overriding
+    # the image's base set of plugins and taking ownership of the plugin's version going forward; and
+    # so we break the link to /usr/lib/jenkins via use of --remove-destination; in the case of centos, it
+    # is not necessary (no links are in play) but has no ill effect so we maintain a common path for
+    # both offerings
+    for FILENAME in /opt/openshift/plugins/* ; do cp --remove-destination $FILENAME ${JENKINS_HOME}/plugins; done
     rm -rf /opt/openshift/plugins
   fi
 

--- a/2/test/s2i/configuration/config.xml
+++ b/2/test/s2i/configuration/config.xml
@@ -49,7 +49,7 @@
   </views>
   <primaryView>All</primaryView>
   <slaveAgentPort>49187</slaveAgentPort>
-  <label>master</label>
+  <label>s2i-test-config</label>
   <nodeProperties/>
   <globalNodeProperties/>
   <noUsageStatistics>true</noUsageStatistics>

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # version (at least that is the initial goal).  This naming system
 # can be revisited in the future if we decide we need either jenkins
 # or <platform> version numbers in the names.
-VERSIONS="1 2 slave-base slave-maven slave-nodejs"
+VERSIONS="2 slave-base slave-maven slave-nodejs"
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7


### PR DESCRIPTION
@jupierce @adammhaile @bparees for recent brew failures

in addition to the raw noarch change, I pulled in migration fixes we had to drop in 3.7 after initially releasing with just the raw noarch change