### PR TITLE
bump sync plugin for blueocean related updates

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:1.0.5
 kubernetes:1.1.3
 
 # fabric8 openshift sync
-openshift-sync:0.9.2
+openshift-sync:1.0.0
 
 # explicitly pull in plugins previously pulled in by dependencies because of
 # security advisories  ...exclude plugins from


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

also declaring this the `1.0.0` version .... no new changes planned for 3.9
and making the `0.` to `1.` transition for typical PR, statement of confidence type reasons