### PR TITLE
bump sync version for stage ordering fix

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ openshift-client:1.0.5
 kubernetes:1.1.3
 
 # fabric8 openshift sync
-openshift-sync:1.0.0
+openshift-sync:1.0.1
 
 # explicitly pull in plugins previously pulled in by dependencies because of
 # security advisories  ...exclude plugins from


### PR DESCRIPTION
@openshift/sig-developer-experience 

per pr description, to pull in recent sync plugin fix for proper order of stages in build annotation leveraged by openshift UI (adjustment on a fix made this release cycle for handling some of the new features introduced with declarative pipeline syntax and blueocean that are not available with the base pipeline support used historically)