### PR TITLE
bump sync and client plugins for recent fixes

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,13 +1,13 @@
 openshift-pipeline:1.0.54
 openshift-login:1.0.4
-openshift-client:1.0.5
+openshift-client:1.0.7
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 kubernetes:1.1.3
 
 # fabric8 openshift sync
-openshift-sync:1.0.2
+openshift-sync:1.0.3
 
 # explicitly pull in plugins previously pulled in by dependencies because of
 # security advisories  ...exclude plugins from


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

for recent client and sync plugin fixes

note, client went from 1.0.5 to 1.0.7 cause 1.0.6 introduced a regression with non default clusters