### PR TITLE
incur jenkins update center pain during startup vs. login via groovy …

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -84,6 +84,7 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/base-plugins.txt && \
     unlink /usr/share/man/man1/unpack200.1.gz && \
     chown -R 1001:0 /opt/openshift && \
     /usr/local/bin/fix-permissions /opt/openshift && \
+    /usr/local/bin/fix-permissions /opt/openshift/configuration/init.groovy.d && \
     /usr/local/bin/fix-permissions /var/lib/jenkins && \
     /usr/local/bin/fix-permissions /var/log
 

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -101,6 +101,7 @@ RUN rm /opt/openshift/base-plugins.txt && \
     chown -R 1001:0 /opt/openshift && \
     # the prior chown doesn't traverse the /opt/openshift/plugins links .. this one will assist fix-permission/assemble for extension builds like master/slave
     chown 1001:0 /usr/lib/jenkins/*hpi && \ 
+    /usr/local/bin/fix-permissions /opt/openshift/configuration/init.groovy.d && \
     /usr/local/bin/fix-permissions /var/lib/jenkins && \
     /usr/local/bin/fix-permissions /var/log
 

--- a/2/contrib/openshift/configuration/init.groovy.d/update-center-init.groovy
+++ b/2/contrib/openshift/configuration/init.groovy.d/update-center-init.groovy
@@ -1,0 +1,3 @@
+import jenkins.model.Jenkins
+Jenkins.getInstance().getPluginManager().doCheckUpdatesServer()
+Jenkins.getInstance().getUpdateCenter().getCoreSource().getData()


### PR DESCRIPTION
…init

@openshift/sig-developer-experience fyi ptal

this a a redo of an end of 3.9 release attempt we made to incur update center delay during startup vs. login

however we quickly met resistance in that image extenders were leveraging the default init.groovy.d/init.groovy

this employ an atypical name which should not conflict, and delves into manipulating the permissions to allow assemble scripts to mess with this

I stopped short of chmod 777 both the dir and the file, but may reconsider