### PR TITLE
allow for the disabling of memory intensive admin monitors via env va…

### DIFF
--- a/2/contrib/openshift/configuration/config.xml.tpl
+++ b/2/contrib/openshift/configuration/config.xml.tpl
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson>
-  <disabledAdministrativeMonitors/>
+  <disabledAdministrativeMonitors>
+    ${ADMIN_MON_CONFIG}
+  </disabledAdministrativeMonitors>
   <version>2.89.2</version>
   <numExecutors>5</numExecutors>
   <mode>NORMAL</mode>

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -28,9 +28,22 @@ function create_jenkins_config_xml() {
     if [ -f "${image_config_path}.tpl" ]; then
       export KUBERNETES_CONFIG=$(generate_kubernetes_config)
       echo "Generating kubernetes-plugin configuration (${image_config_path}.tpl) ..."
+      export ADMIN_MON_CONFIG=$(generate_administrative_monitors_config)
+      echo "Generating administrative monitor configuration (${image_config_path}.tpl) ..."
       envsubst < "${image_config_path}.tpl" > "${image_config_path}"
     fi
   fi
+}
+
+function generate_administrative_monitors_config() {
+  if [[ "${DISABLE_ADMINISTRATIVE_MONITORS}" == "true" ]]; then
+      echo '
+        <string>hudson.model.UpdateCenter$CoreUpdateMonitor</string>
+        <string>jenkins.security.UpdateSiteWarningsMonitor</string>
+      '
+      return
+  fi
+  echo ""
 }
 
 function create_jenkins_credentials_xml() {
@@ -377,6 +390,20 @@ else
 
     install_plugins
   fi  
+fi
+
+if [[ "${DISABLE_ADMINISTRATIVE_MONITORS}" == "true" ]]; then
+    echo "Disabling administrative monitors that contact the update center"
+    if [ -e "${JENKINS_HOME}/init.groovy.d/update-center-init.groovy" ]; then
+	echo "Turning off startup groovy init update center administrative monitor initialization"
+	mv "${JENKINS_HOME}/init.groovy.d/update-center-init.groovy" "${JENKINS_HOME}/init.groovy.d/update-center-init.disabled"
+    fi
+else
+    echo "Administrative monitors that contact the update center will remain active"
+    if [ -e "${JENKINS_HOME}/init.groovy.d/update-center-init.disabled" ]; then
+	echo "Turning on startup groovy init update center administrative monitor initialization"
+	mv "${JENKINS_HOME}/init.groovy.d/update-center-init.disabled" "${JENKINS_HOME}/init.groovy.d/update-center-init.groovy"
+    fi
 fi
 
 if [ -e ${JENKINS_HOME}/password ]; then

--- a/openshift/templates/jenkins-ephemeral.json
+++ b/openshift/templates/jenkins-ephemeral.json
@@ -118,6 +118,10 @@
                     "value": "true"
                   },
                   {
+                    "name": "DISABLE_ADMINISTRATIVE_MONITORS",
+                    "value": "${DISABLE_ADMINISTRATIVE_MONITORS}"
+                  },
+                  {
                     "name": "KUBERNETES_MASTER",
                     "value": "https://kubernetes.default:443"
                   },
@@ -276,6 +280,12 @@
       "displayName": "Jenkins ImageStream Namespace",
       "description": "The OpenShift Namespace where the Jenkins ImageStream resides.",
       "value": "openshift"
+    },
+    {
+      "name": "DISABLE_ADMINISTRATIVE_MONITORS",
+      "displayName": "Disable memory intensive administrative monitors",
+      "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
+      "value": "false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",

--- a/openshift/templates/jenkins-persistent.json
+++ b/openshift/templates/jenkins-persistent.json
@@ -135,6 +135,10 @@
                     "value": "true"
                   },
                   {
+                    "name": "DISABLE_ADMINISTRATIVE_MONITORS",
+                    "value": "${DISABLE_ADMINISTRATIVE_MONITORS}"
+                  },
+                  {
                     "name": "KUBERNETES_MASTER",
                     "value": "https://kubernetes.default:443"
                   },
@@ -300,6 +304,12 @@
       "displayName": "Jenkins ImageStream Namespace",
       "description": "The OpenShift Namespace where the Jenkins ImageStream resides.",
       "value": "openshift"
+    },
+    {
+      "name": "DISABLE_ADMINISTRATIVE_MONITORS",
+      "displayName": "Disable memory intensive administrative monitors",
+      "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
+      "value": "false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",


### PR DESCRIPTION
…r and template param

@openshift/sig-developer-experience ptal

while these update center admin monitors are on by default, these changes will allow us to explicitly turn them off minimally in our extended tests, and possibly in online starter if we chose to do so

Details in https://github.com/openshift/origin/pull/19008