### PR TITLE
move update center init groovy to background thread

### DIFF
--- a/2/contrib/openshift/configuration/init.groovy.d/update-center-init.groovy
+++ b/2/contrib/openshift/configuration/init.groovy.d/update-center-init.groovy
@@ -1,3 +1,27 @@
 import jenkins.model.Jenkins
-Jenkins.getInstance().getPluginManager().doCheckUpdatesServer()
-Jenkins.getInstance().getUpdateCenter().getCoreSource().getData()
+import hudson.security.ACL;
+import jenkins.security.NotReallyRoleSensitiveCallable;
+
+ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
+    public Void call() throws Exception {
+        Thread thread = new Thread(){
+            public void run(){
+                ACL.impersonate(ACL.SYSTEM, new NotReallyRoleSensitiveCallable<Void, Exception>() {
+                    public Void call() throws Exception {
+                            try {
+                                Jenkins.getInstance().getPluginManager().doCheckUpdatesServer();
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                            Jenkins.getInstance().getUpdateCenter().getCoreSource().getData();
+                        return null;
+                    }
+                });
+            }
+        };
+        
+        thread.start();
+        return null;
+    }
+});
+


### PR DESCRIPTION
@openshift/sig-developer-experience ptal

moving these downloads to a separate threads will accelerate jenkins startup to some degree, if sufficient cpu/cores are available, though my testing shows the pod may still not be deemed ready until the download completes, based on whether the readiness probes can squeeze out enough cpu even after the jenkins is up and ready message appears