### PR TITLE
use openssl to strip bag attributes as well

### DIFF
--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -72,10 +72,8 @@ fi
 # generate_kubernetes_config generates a configuration for the kubernetes plugin
 function generate_kubernetes_config() {
     [ -z "$oc_cmd" ] && return
-    [ ! has_service_account ] && return
-    local crt_contents=$(cat "${KUBE_CA}")
-    # do not dump contents of cert here, but allow any error messages to be seen
-    openssl x509 -in $KUBE_CA > /dev/null
+    [ ! has_service_account ] && return   
+    local crt_contents=$(openssl x509 -in "${KUBE_CA}")
     if [ $? -eq 1 ] ; then
       crt_contents=""
     fi


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1548619

@bparees this will actually strip the gorp preceding the -----BEGIN CERTFICATE ------ line 

@bostrt fyi ... with the discussion in the bugzilla, the last change in flight got list and merged before I could update 