### PR TITLE
switch from mv to rsync in assemble script to better account for exis…

### DIFF
--- a/2/contrib/s2i/assemble
+++ b/2/contrib/s2i/assemble
@@ -33,5 +33,5 @@ if [ -d ${JENKINS_INSTALL_DIR}/configuration ]; then
   fi
   echo "---> Installing new Jenkins configuration ..."
   /usr/local/bin/fix-permissions ${JENKINS_INSTALL_DIR}/configuration
-  mv ${JENKINS_INSTALL_DIR}/configuration/* ${JENKINS_DIR}/configuration/
+  rsync -av ${JENKINS_INSTALL_DIR}/configuration/ ${JENKINS_DIR}/configuration
 fi


### PR DESCRIPTION
…ting directories

(Re)Fixes https://github.com/openshift/jenkins/issues/528

In 3.9, we ended up removing the init.groovy.d stuff for GA.

Added it back in 3.10, with a name change for the script, but still did not account for mv not dealing with existing dirs.

@openshift/sig-developer-experience ptal
@jlebon fyi