### PR TITLE
Add support for NPM modules with native extensions

### DIFF
--- a/agent-nodejs-8/Dockerfile
+++ b/agent-nodejs-8/Dockerfile
@@ -13,7 +13,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install NodeJS
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon make gcc-c++" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/agent-nodejs-8/Dockerfile.rhel7
+++ b/agent-nodejs-8/Dockerfile.rhel7
@@ -27,7 +27,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-server-rhscl-8-rpms && \ 
     yum-config-manager --enable rhel-8-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-nodejs-nodemon make gcc-c++" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
It is not possible to test node 8 applications that depend on NPM modules with native extensions. Adding `make` and `gcc-c++` fixes this.

E.g. currently if you run `npm install scrypt` in the `openshift/jenkins-agent-nodejs-8-centos7` container you will receive the following exception:

```shell
$ npm install scrypt

> scrypt@6.0.3 preinstall /var/lib/origin/node_modules/scrypt
> node node-scrypt-preinstall.js

Error: Error: Command failed: ./configure
configure: error: in `/var/lib/origin/node_modules/scrypt/scrypt/scrypt-1.2.0':
configure: error: no acceptable C compiler found in $PATH
See `config.log' for more details


> scrypt@6.0.3 install /var/lib/origin/node_modules/scrypt
> node-gyp rebuild

gyp ERR! build error 
gyp ERR! stack Error: not found: make
gyp ERR! stack     at getNotFoundError (/opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/which.js:13:12)
gyp ERR! stack     at F (/opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/which.js:68:19)
gyp ERR! stack     at E (/opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/which.js:80:29)
gyp ERR! stack     at /opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/which.js:89:16
gyp ERR! stack     at /opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/which/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqWrap.oncomplete (fs.js:152:21)
gyp ERR! System Linux 4.9.87-linuxkit-aufs
gyp ERR! command "/opt/rh/rh-nodejs8/root/usr/bin/node" "/opt/rh/rh-nodejs8/root/usr/lib/node_modules/npm/node_modules.bundled/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /var/lib/origin/node_modules/scrypt
gyp ERR! node -v v8.9.4
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok 
npm WARN enoent ENOENT: no such file or directory, open '/var/lib/origin/package.json'
npm WARN origin No description
npm WARN origin No repository field.
npm WARN origin No README data
npm WARN origin No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! scrypt@6.0.3 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the scrypt@6.0.3 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/jenkins/.npm/_logs/2018-04-11T17_02_28_307Z-debug.log
```