### PR TITLE
temp remove of rpm -V until origin int rhel 7.5 repos picks up fedora…

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -44,7 +44,9 @@ RUN yum-config-manager --disable epel >/dev/null || : && \
     ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
     INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip java-1.8.0-openjdk java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel java-1.8.0-openjdk-devel.i686 atomic-openshift-clients jenkins-2.* jenkins-2-plugins" && \
     yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
+    # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V dejavu-sans-fonts wget rsync gettext git tar zip unzip atomic-openshift-clients jenkins-2.* jenkins-2-plugins && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8
 

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -19,7 +19,9 @@ USER root
 RUN yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless java-1.8.0-openjdk-headless.i686 lsof rsync tar unzip which zip" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
+    # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V bc gettext git lsof rsync tar unzip which zip && \
     yum clean all && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \

--- a/slave-maven/Dockerfile.rhel7
+++ b/slave-maven/Dockerfile.rhel7
@@ -22,7 +22,9 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 java-1.8.0-openjdk-devel.i686 rh-maven33*" && \
     yum install -y $INSTALL_PKGS && \
-    rpm -V ${INSTALL_PKGS//\*/} && \
+    # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V   rh-maven33 && \
     yum clean all -y && \
     mkdir -p $HOME/.m2
 


### PR DESCRIPTION
… fix for java rpms and rpm -V

@openshift/sig-developer-experience fyi

per request from @jupierce , the use of rhel 7.5 in our ci systems is spanning all release branches