### PR TITLE
head off monitor plugin interference (via filter induced session crea…

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -453,7 +453,9 @@ JENKINS_SERVICE_NAME=${JENKINS_SERVICE_NAME:-JENKINS}
 JENKINS_SERVICE_NAME=`echo ${JENKINS_SERVICE_NAME} | tr '[a-z]' '[A-Z]' | tr '-' '_'`
 
 if [[ -z "${JENKINS_JAVA_OPTIONS}" ]]; then
-  JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS -Dfile.encoding=UTF8 $JENKINS_ACCESSLOG"
+    # a discover was made upstream that if the monitor plugin is installed, it creates httpsession's via its filter, which impact the login plugin bearer token support,
+    # so the displayed-counters setting turns that off
+    JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS -Dfile.encoding=UTF8 -Djavamelody.displayed-counters='log,error' $JENKINS_ACCESSLOG"
 fi
 
 # Deal with embedded escaped spaces in JENKINS_JAVA_OVERRIDES.


### PR DESCRIPTION
…tion) with login plugin bearer token support

@openshift/sig-developer-experience fyi

@scoheb discovered this interference to our login plugin's bearer token support recently while building his team's extension to our image

With my ever increasing disdain for more tuning knobs for this image, we are always setting this.  If users want the image to play nice with this monitor plugin and allow the feature we have turned off, they can extend out image.