### PR TITLE
Fix the value of -Djavamelody.displayed-counters

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -455,7 +455,7 @@ JENKINS_SERVICE_NAME=`echo ${JENKINS_SERVICE_NAME} | tr '[a-z]' '[A-Z]' | tr '-'
 if [[ -z "${JENKINS_JAVA_OPTIONS}" ]]; then
     # a discover was made upstream that if the monitor plugin is installed, it creates httpsession's via its filter, which impact the login plugin bearer token support,
     # so the displayed-counters setting turns that off
-    JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS -Dfile.encoding=UTF8 -Djavamelody.displayed-counters='log,error' $JENKINS_ACCESSLOG"
+    JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS -Dfile.encoding=UTF8 -Djavamelody.displayed-counters=log,error $JENKINS_ACCESSLOG"
 fi
 
 # Deal with embedded escaped spaces in JENKINS_JAVA_OVERRIDES.


### PR DESCRIPTION
The single quotes around the value were causing a plugin init fail:

  Caused by: java.lang.IllegalArgumentException: Unknown counter: 'log
      at net.bull.javamelody.FilterContext.setDisplayedCounters(FilterContext.java:237)
      at net.bull.javamelody.FilterContext.initCounters(FilterContext.java:196)