### PR TITLE
Fixes WAR bundled plugins

### DIFF
--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -312,7 +312,7 @@ function bundledPlugins() {
     if [ -f $JENKINS_WAR ]
     then
         TEMP_PLUGIN_DIR=/tmp/plugintemp.$$
-        for i in $(jar tf $JENKINS_WAR | egrep '[^detached-]plugins.*\..pi' | sort)
+        for i in $(jar tf $JENKINS_WAR | egrep '[^detached-plugins].*\..pi' | sort)
         do
             rm -fr $TEMP_PLUGIN_DIR
             mkdir -p $TEMP_PLUGIN_DIR


### PR DESCRIPTION
The regex for finding war bundled plugins is wrong, which having the effect that it never finds any bundled plugins when install-plugins.sh is executed.
