### PR TITLE
default jenkins master, jnlp tunnel, to no_proxy list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 | `OPENSHIFT_PERMISSIONS_POLL_INTERVAL` | Specifies in milliseconds how often the OpenShift Login plugin polls OpenShift for the permissions associated with each user defined in Jenkins. |
 | `INSTALL_PLUGINS`         | Comma-separated list of additional plugins to install on startup. The format of each plugin spec is `plugin-id:version` (as in plugins.txt) |
 |  `OVERRIDE_RELEASE_MIGRATION_OVERWRITE`       | When running this image with an OpenShift persistent volume for the Jenkins config directory, and this image is starting in an existing deployment created with an earlier version of this image, unless the environment variable is set to some non-empty value, the plugins from the image will replace any versions of those plugins currently residing in the Jenkins plugin directory.  |
+|  `SKIP_NO_PROXY_DEFAULT`       | This environment variable applies to the agent/slave images produced by this repository.  By default, the agent/slave images will create/update the 'no_proxy' environment variable with the hostnames for the Jenkins server endpoint and Jenkins JNLP endpoint, as communication flows to endpoints typically should *NOT* go through a HTTP Proxy.  However, if your use case dictates those flows should not be exempt from the proxy, set this environment variable to any non-empty value.    |
 
 
 

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -34,6 +34,28 @@ else
     export MALLOC_ARENA_MAX=1
 fi
 
+if [[ -z "${SKIP_NO_PROXY_DEFAULT}" ]]; then
+    # we do not want jenkins svc or jenkins-jnlp svc
+    # communication going through a http proxy
+    # env vars to consider:
+    # - no_proxy and NO_PROXY; case of string varies tool to tool
+    # - JENKINS_URL and JENKINS_TUNNEL comes from k8s plugin
+    # based on how our master image configures the cloud, but we need to strip the host / port
+    jenkins_http_host=`echo $JENKINS_URL | sed 's#https://##' | sed 's#http://##' | cut -f1 -d":"`
+    jnlp_http_host=`echo $JENKINS_TUNNEL | sed 's#https://##' | sed 's#http://##' | cut -f1 -d":"`
+    # check if set to avoid having a comma as the last char
+    if [[ -z "${no_proxy}" ]]; then
+       export no_proxy=$jenkins_http_host,$jnlp_http_host
+    else
+	export no_proxy=$jenkins_http_host,$jnlp_http_host,$no_proxy
+    fi
+    if [[ -z "${NO_PROXY}" ]]; then
+       export NO_PROXY=$jenkins_http_host,$jnlp_http_host
+    else
+	export NO_PROXY=$jenkins_http_host,$jnlp_http_host,$NO_PROXY
+    fi
+fi
+
 # Configure the slave image
 source /usr/local/bin/configure-slave
 


### PR DESCRIPTION
cherry-picked master fix to create 3.6 version fix for https://bugzilla.redhat.com/show_bug.cgi?id=1573648

@openshift/sig-developer-experience ptal

Have tested against 3.6 cluster using the current k8s plugin we ship there, namely v0.10