### PR TITLE
Add save-artifacts s2i script for incremental builds

### DIFF
--- a/2/contrib/s2i/assemble
+++ b/2/contrib/s2i/assemble
@@ -3,6 +3,8 @@
 JENKINS_DIR=/opt/openshift
 JENKINS_INSTALL_DIR=$(mktemp -d --suffix=jenkins)
 
+INCREMENTAL_BUILD_ARTIFACTS_DIR=/tmp/artifacts
+
 shopt -s dotglob
 
 echo "---> Copying repository files ..."
@@ -19,6 +21,9 @@ if [ -f ${JENKINS_INSTALL_DIR}/plugins.txt ]; then
   fi
   /usr/local/bin/fix-permissions ${JENKINS_DIR}/plugins
 fi
+
+echo "Deleting $INCREMENTAL_BUILD_ARTIFACTS_DIR/plugins"
+rm -rf "$INCREMENTAL_BUILD_ARTIFACTS_DIR/plugins"
 
 if [ -d ${JENKINS_INSTALL_DIR}/plugins ]; then
   echo "---> Installing $(ls -l ${JENKINS_INSTALL_DIR}/plugins | grep ^- | wc -l) Jenkins plugins from plugins/ directory ..."

--- a/2/contrib/s2i/save-artifacts
+++ b/2/contrib/s2i/save-artifacts
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+pushd "/opt/openshift" > /dev/null
+if [ -d plugins ]; then
+    tar cf - ./plugins
+fi
+popd > /dev/null


### PR DESCRIPTION
I was trying to keep the changes to a minimum to avoid a big divergence from the upstream `install-plugins.sh`. However, that means the change is not as clean as it could be. Let me know what you think - I could refactor the `download` and `doDownload` functions a bit more to avoid duplication at the cost of diverging from the upstream.

I've tested this with our image, which installs about 80 plugins, and the (incremental) build time got from 200s to about 35s.