### PR TITLE
add NPM_MIRROR_URL support to use a node mirror registry

### DIFF
--- a/agent-nodejs-8/README.md
+++ b/agent-nodejs-8/README.md
@@ -1,0 +1,9 @@
+Node Slave Image
+====================
+
+This repository contains Dockerfiles for a Jenkins Agent Docker image intended for 
+use with [OpenShift v3](https://github.com/openshift/origin)
+
+Node Registry Support
+---------------------------------
+This Node agent image supports using a [Node Mirror/Registry](https://blog.sonatype.com/using-nexus-3-as-your-repository-part-2-npm-packages) manager such as Sonatype Nexus 3 via setting the NPM_MIRROR_URL environment variable on the slave pod

--- a/agent-nodejs-8/contrib/bin/configure-agent
+++ b/agent-nodejs-8/contrib/bin/configure-agent
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -n "$NPM_MIRROR_URL" ]; then
+  npm -g config set registry "$NPM_MIRROR_URL"
+fi


### PR DESCRIPTION
As mentioned https://github.com/openshift/jenkins/pull/545#issuecomment-389445502, I split it in favour of 2 distinct PR.

This enable a similar customization as maven agent but for node registry instead of maven repository.