### PR TITLE
similar to rhel, bypass on centos of rpm -V on java rpms

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -38,7 +38,9 @@ RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/j
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel.i686 ; fi) && \
     INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-1.8.0-openjdk jenkins-2.107.3-1.1" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
-    rpm -V $INSTALL_PKGS $x86_EXTRA_RPMS && \
+    # have temporarily removed the validation for java to work around known problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V  dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init jenkins-2.107.3-1.1 && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8
 

--- a/agent-maven-3.5/Dockerfile
+++ b/agent-maven-3.5/Dockerfile
@@ -18,7 +18,9 @@ RUN INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 rh-maven35*" && \
     unzip gradle-${GRADLE_VERSION}-bin.zip -d /opt && \
     rm -f gradle-${GRADLE_VERSION}-bin.zip && \
     ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    rpm -V ${INSTALL_PKGS//\*/} ${x86_EXTRA_RPMS//\*/} && \
+    # have temporarily removed the validation for java to work around known problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V rh-maven35 && \
     yum clean all -y && \
     mkdir -p $HOME/.m2 && \
     mkdir -p $HOME/.gradle

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -10,7 +10,9 @@ RUN yum install -y centos-release-scl-rh && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk-headless.i686 ; fi) && \
     INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2" && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
-    rpm -V $INSTALL_PKGS $x86_EXTRA_RPMS && \
+    # have temporarily removed the validation for java to work around known problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V bc gettext git lsof rsync tar unzip which zip bzip2  && \
     yum clean all && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \

--- a/slave-maven/Dockerfile
+++ b/slave-maven/Dockerfile
@@ -18,7 +18,9 @@ RUN INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 rh-maven33*" && \
     unzip gradle-${GRADLE_VERSION}-bin.zip -d /opt && \
     rm -f gradle-${GRADLE_VERSION}-bin.zip && \
     ln -s /opt/gradle-${GRADLE_VERSION} /opt/gradle && \
-    rpm -V ${INSTALL_PKGS//\*/} ${x86_EXTRA_RPMS//\*/} && \
+    # have temporarily removed the validation for java to work around known problem fixed in fedora; jupierce and gmontero are working with
+    # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs
+    rpm -V  rh-maven33 && \
     yum clean all -y && \
     mkdir -p $HOME/.m2 && \
     mkdir -p $HOME/.gradle


### PR DESCRIPTION
See recent test failures in https://github.com/openshift/jenkins/pull/623

@openshift/sig-developer-experience @openshift/sig-continuous-delivery @grdryn fyi