### PR TITLE
Add default git config

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -89,7 +89,10 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/base-plugins.txt && \
     /usr/local/bin/fix-permissions /opt/openshift && \
     /usr/local/bin/fix-permissions /opt/openshift/configuration/init.groovy.d && \
     /usr/local/bin/fix-permissions /var/lib/jenkins && \
-    /usr/local/bin/fix-permissions /var/log
+    /usr/local/bin/fix-permissions /var/log && \
+    git config --global user.email "openshift@openshift.com" && \
+    git config --global user.name "openshift"
+
 
 VOLUME ["/var/lib/jenkins"]
 

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -106,7 +106,10 @@ RUN rm /opt/openshift/base-plugins.txt && \
     chown 1001:0 /usr/lib/jenkins/*hpi && \ 
     /usr/local/bin/fix-permissions /opt/openshift/configuration/init.groovy.d && \
     /usr/local/bin/fix-permissions /var/lib/jenkins && \
-    /usr/local/bin/fix-permissions /var/log
+    /usr/local/bin/fix-permissions /var/log && \
+    git config --global user.email "openshift@openshift.com" && \
+    git config --global user.name "openshift"
+
 
 VOLUME ["/var/lib/jenkins"]
 

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -47,7 +47,9 @@ RUN yum install -y centos-release-scl-rh && \
     unlink /usr/share/man/man1/rmiregistry.1.gz && \
     unlink /usr/share/man/man1/servertool.1.gz && \
     unlink /usr/share/man/man1/tnameserv.1.gz && \
-    unlink /usr/share/man/man1/unpack200.1.gz
+    unlink /usr/share/man/man1/unpack200.1.gz && \
+    git config --global user.email "openshift@openshift.com" && \
+    git config --global user.name "openshift"
 
 # Copy the entrypoint
 ADD contrib/bin/* /usr/local/bin/

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -57,7 +57,9 @@ RUN yum-config-manager --disable epel >/dev/null || : && \
     unlink /usr/share/man/man1/rmiregistry.1.gz && \
     unlink /usr/share/man/man1/servertool.1.gz && \
     unlink /usr/share/man/man1/tnameserv.1.gz && \
-    unlink /usr/share/man/man1/unpack200.1.gz
+    unlink /usr/share/man/man1/unpack200.1.gz && \
+    git config --global user.email "openshift@openshift.com" && \
+    git config --global user.name "openshift"
 
 # Copy the entrypoint
 ADD contrib/bin/* /usr/local/bin/


### PR DESCRIPTION
Opening this PR for #619.

Just to show the config is working in the centos image...
```
bash-4.2$ git config --list
user.email=openshift@openshift.com
user.name=openshift
```

I understand this is pending "what will/should this base out of the box jenkins master contain."

Thanks!

fixes https://github.com/openshift/jenkins/issues/619
