### PR TITLE
bump sync/client plugins for recent fixes

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
 openshift-pipeline:1.0.54
 openshift-login:1.0.8
-openshift-client:1.0.12
+openshift-client:1.0.13
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
@@ -12,7 +12,7 @@ openshift-client:1.0.12
 kubernetes:1.7.1
 
 # fabric8 openshift sync
-openshift-sync:1.0.19
+openshift-sync:1.0.20
 
 # explicitly pull in plugins previously pulled in by dependencies because of
 # security advisories  ...exclude plugins from


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

also, still sorting out with @openshift/sig-continuous-delivery and/or @openshift/sig-continuous-infrastructure on who owns the plumbing behind https://buildvm.openshift.eng.bos.redhat.com:8443/job/devex/job/devex%252Fjenkins-plugins/ after the recent reorg and whether we can generate plugin rpms for 3.11

