### PR TITLE
turn on k8s feature we added to transfer proxy settings from master t…

### DIFF
--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -146,6 +146,7 @@ function generate_kubernetes_config() {
       </templates>
       <serverUrl>https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}</serverUrl>
       <skipTlsVerify>false</skipTlsVerify>
+      <addMasterProxyEnvVars>true</addMasterProxyEnvVars>
       <serverCertificate>${crt_contents}</serverCertificate>
       <namespace>${PROJECT_NAME}</namespace>
       <jenkinsUrl>http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}</jenkinsUrl>


### PR DESCRIPTION
…o agents

@openshift/sig-developer-experience fyi / ptal

Another Boehringer action item.  This turns on the new bit I added to the k8s plugin that allows any proxy/no_proxy related env vars on the master to be set on any agent launched.

Reminder, if you look high enough up `generate_kubernetes_config()` you'll see the `has_service_account` check.  This ensures that this image is running as an openshift pod, which is when we would like to have this behavior enabled.  But if the user is running the image outside a pod, we leave the default behavior.