### PR TITLE
bump container cap to 100

### DIFF
--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -152,7 +152,7 @@ function generate_kubernetes_config() {
       <jenkinsUrl>http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}</jenkinsUrl>
       <jenkinsTunnel>${JNLP_HOST}:${JNLP_PORT}</jenkinsTunnel>
       <credentialsId>1a12dfa4-7fc5-47a7-aa17-cc56572a41c7</credentialsId>
-      <containerCap>10</containerCap>
+      <containerCap>100</containerCap>
       <retentionTimeout>5</retentionTimeout>
     </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
     "


### PR DESCRIPTION
Due to the nature of Jenkins, I have found the container cap to be quite low. Even for new consumers testing the OpenShift Jenkins, I believe will hit this cap very quickly which turns into a poor user experience. IMHO.