### PR TITLE
bump client, sync plugin versions for recent changes

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
 openshift-pipeline:1.0.54
 openshift-login:1.0.9
-openshift-client:1.0.13
+openshift-client:1.0.14
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
@@ -12,7 +12,7 @@ openshift-client:1.0.13
 kubernetes:1.7.1
 
 # fabric8 openshift sync
-openshift-sync:1.0.20
+openshift-sync:1.0.23
 
 # we leverage this plugin in the openshift-client DSL groovy shim
 lockable-resources:2.3


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

note, the sync plugin jump from 20 to 23 was not a mistake ... just managed to cut new versions of the sync plugin for fixes before I cut a new jenkins image with the updated versions