### PR TITLE
Update the nodejs slave image to version 8

### DIFF
--- a/slave-nodejs/Dockerfile
+++ b/slave-nodejs/Dockerfile
@@ -2,7 +2,7 @@ FROM openshift/jenkins-slave-base-centos7
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 
-ENV NODEJS_VERSION=4.4 \
+ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \
@@ -13,7 +13,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 
 # Install NodeJS
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-npm rh-nodejs8-nodejs-nodemon" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/slave-nodejs/Dockerfile.rhel7
+++ b/slave-nodejs/Dockerfile.rhel7
@@ -11,7 +11,7 @@ LABEL com.redhat.component="jenkins-slave-nodejs-rhel7-container" \
       io.k8s.description="The jenkins slave nodejs image has the nodejs tools on top of the jenkins slave base image." \
       io.openshift.tags="openshift,jenkins,slave,nodejs"
 
-ENV NODEJS_VERSION=4.4 \
+ENV NODEJS_VERSION=8 \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
     BASH_ENV=/usr/local/bin/scl_enable \
@@ -24,7 +24,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \    
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-nodejs-nodemon" && \
+    INSTALL_PKGS="rh-nodejs8 rh-nodejs8-nodejs-nodemon" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/slave-nodejs/contrib/bin/scl_enable
+++ b/slave-nodejs/contrib/bin/scl_enable
@@ -1,3 +1,3 @@
 # This will make scl collection binaries work out of box.
 unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-nodejs4
+source scl_source enable rh-nodejs8


### PR DESCRIPTION
Hey all,

Raising this pull request if it is feasible to update the nodejs slave image to version 8

If there is something blocker or breaking in this, feel free to advise as I am not aware of that.

It will be good if something like -> for current version ( node 4) -> image `openshift/jenkins-slave-nodejs-centos7

and after update, node 8 -> image `openshift/jenkins-slave-nodejs8-centos7` or may be vice versa

cc @gabemontero @sthaha @hrishin