### PR TITLE
Dockerfile edits and set java path for multiarch builds 

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -42,7 +42,7 @@ RUN yum-config-manager --disable epel >/dev/null || : && \
     # will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images do *NOT* have a /usr/lib64/jenkins path
     ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel.i686 ; fi) && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-1.8.0-openjdk atomic-openshift-clients jenkins-2.* jenkins-2-plugins" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-1.8.0-openjdk java-1.8.0-openjdk-devel atomic-openshift-clients jenkins-2.* jenkins-2-plugins" && \
     yum install -y $INSTALL_PKGS $x86_EXTRA_RPMS && \
     # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
     # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -186,6 +186,10 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
 	alternatives --set javac $(alternatives --display javac | awk '/family.*i386/ { print $1; }')
 	export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-1}
     fi
+#set JVM for all other archs
+else
+        alternatives --set java $(alternatives --display java | awk '/family.*'$(uname -m)'/ { print $1; }')
+        alternatives --set javac $(alternatives --display javac | awk '/family.*'$(uname -m)'/ { print $1; }')
 fi
 
 echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -173,7 +173,7 @@ function force_copy_plugins() {
 CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
-# multi-arch check ... if not x86_64, leave alone
+# multi-arch check ... if x86_64, pick between 32 and 64 bit
 if [[ "$(uname -m)" == "x86_64" ]]; then
     # Set the JVM architecture used.  Follow OPENSHIFT_JENKINS_JVM_ARCH if set.  If
     # not, use 32 bit JVM for space efficiency if container size < 2GiB

--- a/agent-maven-3.5/Dockerfile.rhel7
+++ b/agent-maven-3.5/Dockerfile.rhel7
@@ -20,7 +20,7 @@ ENV MAVEN_VERSION=3.5 \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-server-rhscl-8-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 rh-maven35*" && \
+    INSTALL_PKGS="java-1.8.0-openjdk-devel rh-maven35*" && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk-devel.i686 ; fi) && \
     yum install -y $INSTALL_PKGS $x86_EXTRA_RPMS && \
     # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -29,6 +29,9 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
       alternatives --set java $(alternatives --display java | awk '/family.*i386/ { print $1; }')
       export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-1}
     fi
+#set JVM for all other archs
+else
+        alternatives --set java $(alternatives --display java | awk '/family.*'$(uname -m)'/ { print $1; }')
 fi
 
 echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java)"

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -18,7 +18,7 @@ source /usr/local/bin/generate_container_user
 CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
-# multi-arch check ... if not x86_64, leave alone
+# multi-arch check ... if x86_64, pick between 32 and 64 bit 
 if [[ "$(uname -m)" == "x86_64" ]]; then
     # Set the JVM architecture used.  Follow OPENSHIFT_JENKINS_JVM_ARCH if set.  If
     # not, use 32 bit JVM for space efficiency if container size < 2GiB

--- a/slave-maven/Dockerfile.rhel7
+++ b/slave-maven/Dockerfile.rhel7
@@ -19,7 +19,7 @@ ENV MAVEN_VERSION=3.3 \
 # Install Maven
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 rh-maven33*" && \
+    INSTALL_PKGS="java-1.8.0-openjdk-devel rh-maven33*" && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk-devel.i686 ; fi) && \
     yum install -y $INSTALL_PKGS $x86_EXTRA_RPMS && \
     # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with


### PR DESCRIPTION
Dockerfile changes needed to build ppc64le + x86 containers from same Dockerfile.

Adding  java/javac to 'alternatives' logic so ppc64le (and other archs) can successfully start jenkins.