### PR TITLE
Update openshift-client plugin to 1.0.20

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
 openshift-pipeline:1.0.55
 openshift-login:1.0.9
-openshift-client:1.0.18
+openshift-client:1.0.20
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
This updates the openshift-client plugin to 1.0.20 so that trailing builds in Jenkins builds will work.