### PR TITLE
fix for nss version mismatch between x86/ppc64le caused by java*.i686…

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -43,6 +43,7 @@ RUN yum-config-manager --disable epel >/dev/null || : && \
     ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk.i686 java-1.8.0-openjdk-devel.i686 ; fi) && \
     INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-1.8.0-openjdk atomic-openshift-clients jenkins-2.* jenkins-2-plugins" && \
+    yum -y update nss && \
     yum install -y $INSTALL_PKGS $x86_EXTRA_RPMS && \
     # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
     # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -18,6 +18,7 @@ USER root
 RUN yum-config-manager --disable epel >/dev/null || : && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-1.8.0-openjdk-headless.i686 ; fi) && \
     INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2" && \
+    yum -y update nss && \
     yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
     # have temporarily removed the validation for java to work aroun known rhel 7.5 problem fixed in fedora; jupierce and gmontero are working with
     # the requisit folks to get that addressed ... will switch back to rpm -V $INSTALL_PKGS when that occurs


### PR DESCRIPTION
Multi-Arch Jenkins builds are failing because of nss version mismatch between x86/power containers. The mismatch exists b/c then installation of java*.i686 forces and nss update. We are working on getting this fixed in RHEL, but that will take some time. In the meantime, this will let the ART team build successfully.
@gabemontero can you cherrypick to release-3.11 and release-3.10?