### PR TITLE
suggestion

### DIFF
--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -430,7 +430,7 @@ main() {
     fi
 
     echo -e "\nCleaning up locks"
-    rm -r "$REF_DIR"/*.lock
+    rm -rf "$REF_DIR"/*.lock
 }
 
 main "$@"


### PR DESCRIPTION
if your plugins.txt is empty, then *.lock will not be created and your code in line 433 crashed with 
``rm: cannot remove ‘/opt/openshift/plugins/*.lock’: No such file or directory``

is not good for me 😉