### PR TITLE
🔒 Upgrade plugin versions for security-1266

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -32,6 +32,7 @@ lockable-resources:2.3
 # processed sec adv https://jenkins.io/security/advisory/2018-06-25/
 # processed sec adv https://jenkins.io/security/advisory/2018-09-25/
 # processed sec adv https://jenkins.io/security/advisory/2018-10-29/
+# processed sec adv https://jenkins.io/security/advisory/2019-01-08/
 #
 htmlpublisher:1.16
 mailer:1.21
@@ -41,7 +42,7 @@ job-dsl:1.70
 parameterized-trigger:2.35.2
 pipeline-build-step:2.7
 pipeline-input-step:2.8
-script-security:1.48
+script-security:1.50
 credentials-binding:1.15
 junit:1.26.1
 workflow-durable-task-step:2.18
@@ -52,7 +53,8 @@ subversion:2.10.3
 github:1.29.2
 github-branch-source:2.3.6
 jira:3.0.2
-workflow-cps:2.60
+workflow-cps:2.61.1
+pipeline-model-definition:1.3.4.1
 
 # Legacy stuff
 mapdb-api:1.0.9.0

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-login:1.0.12
-openshift-client:1.0.23
+openshift-client:1.0.24
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
From https://jenkins.io/security/advisory/2019-01-08/#SECURITY-1266:

```
SECURITY-1266 / CVE pending

Script Security sandbox protection could be circumvented during the
script compilation phase by applying AST transforming annotations such
as @Grab to source code elements.

Both the pipeline validation REST APIs and actual script/pipeline
execution are affected.

This allowed users with Overall/Read permission, or able to control
Jenkinsfile or sandboxed Pipeline shared library contents in SCM, to
bypass the sandbox protection and execute arbitrary code on the
Jenkins master.

All known unsafe AST transformations in Groovy are now prohibited in
sandboxed scripts.
```

On the Update page in the Plugin Manager inside Jenkins, for the
"Pipeline: Declarative" (pipeline-model-definition), there's the
following warning message in red:

> Warning: This plugin requires dependent plugins be upgraded and at
> least one of these dependent plugins claims to use a different
> settings format than the installed version. Jobs using that plugin
> may need to be reconfigured, and/or you may not be able to cleanly
> revert to the prior version without manually restoring old
> settings. Consult the plugin release notes for details.