### PR TITLE
bump login plugin for correct api version for self-sar on 4.0

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-login:1.0.13
+openshift-login:1.0.14
 openshift-client:1.0.24
 
 


### PR DESCRIPTION
/assign @bparees 

as you noted elsewhere, with our forcing the jenkins imagestream to what is on docker.io in the openshift/origin e2e and no longer tagging in the newly built image with our special openshift/release template, we won't test this change until after this merges (other than my local testing)