### PR TITLE
use non-alpha version of oc cli on 3.11 slave-base

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin:v3.11
+FROM quay.io/openshift/origin-cli:v3.11
 
 # Jenkins image for OpenShift
 #

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/ose:v3.11
+FROM registry.access.redhat.com/openshift3/ose-cli:v3.11
 
 # Jenkins image for OpenShift
 #

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin:v3.11
+FROM quay.io/openshift/origin-cli:v3.11
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/ose:v3.11
+FROM registry.access.redhat.com/openshift3/ose-cli:v3.11
 
 MAINTAINER Ben Parees <bparees@redhat.com>
 


### PR DESCRIPTION
The current slave-base image for v3.11 uses an alpha version of the oc cli:

```
$ docker pull openshift/jenkins-slave-base-centos7:v3.11
v3.11: Pulling from openshift/jenkins-slave-base-centos7
Digest: sha256:9aecbcc01b854c1050117dd567645faea2e1aa06697d5e5108519981883f0993
Status: Downloaded newer image for openshift/jenkins-slave-base-centos7:v3.11

$ docker run -ti openshift/jenkins-slave-base-centos7:v3.11 /bin/bash
bash-4.2# oc version
oc v3.11.0-alpha.0+1ff2229-9
kubernetes v1.10.0+b81c8f8
features: Basic-Auth GSSAPI Kerberos SPNEGO
``` 

Besides being an alpha version, it also does not have some features available in the released version, like `oc wait`.

This PR changes the base image to use quay.io since the image from docker hub is deprecated since 3.10.