### PR TITLE
🔒 Upgrade plugins for Jenkins advisory 2018-09-25

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -32,6 +32,7 @@ lockable-resources:2.3
 # processed sec adv https://jenkins.io/security/advisory/2018-06-04/
 # processed sec adv https://jenkins.io/security/advisory/2018-06-25/
 # processed sec adv https://jenkins.io/security/advisory/2018-09-25/
+# processed sec adv https://jenkins.io/security/advisory/2018-10-29/
 # processed sec adv https://jenkins.io/security/advisory/2019-01-08/
 # processed sec adv https://jenkins.io/security/advisory/2019-01-28/
 #

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -31,6 +31,7 @@ lockable-resources:2.3
 # processed sec adv https://jenkins.io/security/advisory/2018-04-16/
 # processed sec adv https://jenkins.io/security/advisory/2018-06-04/
 # processed sec adv https://jenkins.io/security/advisory/2018-06-25/
+# processed sec adv https://jenkins.io/security/advisory/2018-09-25/
 # processed sec adv https://jenkins.io/security/advisory/2019-01-08/
 # processed sec adv https://jenkins.io/security/advisory/2019-01-28/
 #
@@ -44,7 +45,7 @@ pipeline-build-step:2.7
 pipeline-input-step:2.8
 script-security:1.50
 credentials-binding:1.15
-junit:1.24
+junit:1.26.1
 workflow-durable-task-step:2.18
 workflow-support:2.18
 git:3.9.3
@@ -53,6 +54,7 @@ subversion:2.10.3
 github:1.29.2
 github-branch-source:2.3.6
 workflow-cps:2.61.1
+jira:3.0.2
 pipeline-model-definition:1.3.4.1
 token-macro:2.6
 


### PR DESCRIPTION
https://jenkins.io/security/advisory/2018-09-25/

Note: the 2019 sec advisories bumped config-file-provider to 3.5 so we did not pull the 3.2 bump from https://github.com/openshift/jenkins/pull/709