### PR TITLE
🔒 Upgrade to latest LTS 2.164.2

### DIFF
--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -11,8 +11,8 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == "false" ]]; then
     if [ "$#" == "1" ]; then
         YUM_FLAGS="$1"
     fi
-    yum -y $YUM_FLAGS --setopt=tsflags=nodocs install jenkins-2.150.2-1.1
-    rpm -V jenkins-2.150.2-1.1
+    yum -y $YUM_FLAGS --setopt=tsflags=nodocs install jenkins-2.164.2-1.1
+    rpm -V jenkins-2.164.2-1.1
     yum clean all
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else
@@ -30,5 +30,3 @@ else
     for FILENAME in /usr/lib/jenkins/*hpi ; do ln -s $FILENAME /opt/openshift/plugins/`basename $FILENAME .hpi`.jpi; done
     chown 1001:0 /usr/lib/jenkins/*hpi
 fi
-
-


### PR DESCRIPTION
We never upgraded to 2.164.1 because there were no security fixes, but
now 2.164.2. See the changelog for all changes:

https://jenkins.io/changelog-stable/