### PR TITLE
Bug 1709626: fix pod template tracking in the sync plugin so pod temp…

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ openshift-client:1.0.30
 kubernetes:1.12.8
 
 # fabric8 openshift sync
-openshift-sync:1.0.34
+openshift-sync:1.0.37
 
 # we leverage this plugin in the openshift-client DSL groovy shim
 lockable-resources:2.5


### PR DESCRIPTION
…lates are not inadvertently delete when config maps and imagestreams have the same name; also grants ownership of the pod template to whichever type's event comes in first