### PR TITLE
Bug 1709575: login plugin account for the jenkins SA certificate diff…

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,4 +1,4 @@
-openshift-login:1.0.16
+openshift-login:1.0.17
 openshift-client:1.0.30
 
 


### PR DESCRIPTION
…ering from the oauth server's router certificate (where SSL handshake errors would then occur with jenkins SA certificate) by falling back to the JVM's default keystore