### PR TITLE
various clean up to get 'make test' functional again for PR testing

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -179,7 +179,7 @@ else
   alternatives --set javac $(alternatives --display javac | awk '/family.*'$(uname -m)'/ { print $1; }')
 fi
 
-echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"
+echo "CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"
 
 image_config_dir="/opt/openshift/configuration"
 image_config_path="${image_config_dir}/config.xml"

--- a/agent-maven-3.5/test/agent_maven_test.go
+++ b/agent-maven-3.5/test/agent_maven_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -92,26 +91,4 @@ var _ = Describe("Maven Agent testing", func() {
 		Expect(code).To(Equal(0))
 	})
 
-	It("should contain a runnable gradle", func() {
-		if strings.Contains(imageName, "rhel") {
-			Skip("n/a on RHEL image")
-		}
-
-		var err error
-		id, err = dockercli.ContainerCreate(
-			&container.Config{
-				Image:      imageName,
-				Cmd: []string{"gradle"},
-				Tty:        true,
-			},
-			nil)
-		Expect(err).NotTo(HaveOccurred())
-
-		err = dockercli.ContainerStart(id)
-		Expect(err).NotTo(HaveOccurred())
-
-		code, err := dockercli.ContainerWait(id)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(code).To(Equal(0))
-	})
 })

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -9,7 +9,7 @@ USER root
 RUN curl https://copr.fedorainfracloud.org/coprs/alsadi/dumb-init/repo/epel-7/alsadi-dumb-init-epel-7.repo -o /etc/yum.repos.d/alsadi-dumb-init-epel-7.repo && \
     curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \
     curl http://mirror.centos.org/centos-7/7/os/x86_64/RPM-GPG-KEY-CentOS-7 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2" && \
+    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 dumb-init" && \
     DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
     yum $DISABLES install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \


### PR DESCRIPTION
/assign @akram 
/assign @waveywaves 

step one in getting the old docker socket based unt/cmd line tests back into PR verification

these tests had been out of the loop for long enough they needed some cleanup

both openshift/aos-cd-jobs and  openshift/release PR will follow once this merges 