### PR TITLE
remove all yum-config-manager invocations from Dockerfiles

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -40,12 +40,11 @@ LABEL com.redhat.component="openshift-jenkins-2-container" \
 # 8080 for main web interface, 50000 for slave agents
 EXPOSE 8080 50000
 
-RUN yum-config-manager --disable epel >/dev/null || : && \
-    yum-config-manager --enable rhel-7-server-ose-onlineint-rpms || : && \
-    # for backward compatibility with pre-3.6 installs leveraging a PV, where rpm installs went to /usr/lib64/jenkins, we are
-    # establishing a symbolic link for that guy as well, so that existing plugins in JENKINS_HOME/plugins pointing to /usr/lib64/jenkins
-    # will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images do *NOT* have a /usr/lib64/jenkins path
-    ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
+# for backward compatibility with pre-3.6 installs leveraging a PV, where rpm installs went to /usr/lib64/jenkins, we are
+# establishing a symbolic link for that guy as well, so that existing plugins in JENKINS_HOME/plugins pointing to 
+# /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images 
+# do *NOT* have a /usr/lib64/jenkins path
+RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
     INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \

--- a/agent-maven-3.5/Dockerfile.rhel7
+++ b/agent-maven-3.5/Dockerfile.rhel7
@@ -16,10 +16,7 @@ ENV MAVEN_VERSION=3.5 \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable"
 
 # Install Maven
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum-config-manager --enable rhel-server-rhscl-8-rpms && \
-    yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="java-1.8.0-openjdk-devel rh-maven35*" && \
+RUN INSTALL_PKGS="java-1.8.0-openjdk-devel rh-maven35*" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V  java-1.8.0-openjdk-devel rh-maven35 && \
     yum clean all -y && \

--- a/agent-nodejs-8/Dockerfile.rhel7
+++ b/agent-nodejs-8/Dockerfile.rhel7
@@ -22,12 +22,7 @@ COPY contrib/bin/scl_enable /usr/local/bin/scl_enable
 COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
 
 # Install NodeJS
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \    
-    yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum-config-manager --enable rhel-server-rhscl-8-rpms && \ 
-    yum-config-manager --enable rhel-8-server-optional-rpms && \
-    yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-nodejs-nodemon make gcc-c++" && \
+RUN INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-nodejs-nodemon make gcc-c++" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -15,8 +15,7 @@ ENV HOME=/home/jenkins
 
 USER root
 # Install headless Java
-RUN yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 dumb-init" && \
+RUN INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 dumb-init" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \


### PR DESCRIPTION
let's see what breaks. In theory nothing should since yum-config-manager
is no-op'ing anyway.

OSBS strips these yum-config-manager invocations and on the origin/CI side of the house, they are being no-op'd, so they should have no effect there either.
