### PR TITLE
Bug NEED CLONE 1732346: Bump Credentials Binding Plugin to v1.19

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -50,7 +50,7 @@ pipeline-build-step:2.7
 pipeline-input-step:2.8
 script-security:1.56
 credentials:2.1.19 
-credentials-binding:1.15
+credentials-binding:1.19
 junit:1.26.1
 workflow-support:2.18
 git:3.9.3


### PR DESCRIPTION
Bug 1732346: (CVE-2019-1010241) - CVE-2019-1010241 jenkins-plugin-credentials-binding: storing passwords in recoverable format leading to authenticated users being able to recover credentials