### PR TITLE
Bug 1735527: 3.11 cve 2019 10357 bump workflow cps global lib version to 2.15

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -21,6 +21,7 @@ lockable-resources:2.5
 # also, as the plugins above raise their dependency levels for these plugins let's see about removing
 # items from the list below
 #
+# 
 # processed sec adv https://jenkins.io/blog/2017/07/10/security-advisory/
 # processed sec adv https://jenkins.io/security/advisory/2017-08-07/
 # processed sec adv https://jenkins.io/security/advisory/2018-01-22/
@@ -40,6 +41,7 @@ lockable-resources:2.5
 # processed sec adv https://jenkins.io/security/advisory/2019-05-21/
 # processed sec adv https://jenkins.io/security/advisory/2019-05-31/
 # processed sec adv https://jenkins.io/security/advisory/2019-06-11/
+# processed sec adv https://jenkins.io/security/advisory/2019-07-31/
 #
 htmlpublisher:1.16
 mailer:1.21
@@ -61,6 +63,7 @@ subversion:2.10.3
 github:1.29.2
 github-branch-source:2.3.6
 workflow-cps:2.65
+workflow-cps-global-lib:2.15
 pipeline-model-definition:1.3.4.1
 token-macro:2.8
 workflow-remote-loader:1.5


### PR DESCRIPTION
This PR fixes the following CVE
https://jenkins.io/security/advisory/2019-07-31/
