### PR TITLE
Bump plugin versions wrt workflow-cps fix in client plugin

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -60,7 +60,7 @@ mercurial:2.3
 subversion:2.10.3
 github:1.29.2
 github-branch-source:2.3.6
-workflow-cps:2.65
+workflow-cps:2.73
 workflow-cps-global-lib:2.15
 pipeline-model-definition:1.3.4.1
 token-macro:2.8

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 openshift-login:1.0.19
-openshift-client:1.0.30
+openshift-client:1.0.32
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin


### PR DESCRIPTION
Updates: 

Wrt the fix in https://github.com/openshift/jenkins-client-plugin/pull/287 workflow-cps plugin versions above 2.71 are now usable as they do not give the warning it used to before which was due to a bug in the jenkins client plugin itself which was also solved in the PR above.

Plugins updating:
workflow-cps FROM 2.65 -> 2.73
jenkins-client-plugin FROM 2.65 -> 2.73

/assign @akram 
/assign @gabemontero 