### PR TITLE
Bump openshift-jenkins-login-plugin to version 1.0.20

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,8 @@
-openshift-login:1.0.19
+
+# OpenShift Plugins
+openshift-login:1.0.20
 openshift-client:1.0.32
+openshift-sync:1.0.41
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
@@ -7,9 +10,6 @@ openshift-client:1.0.32
 # 1.12.0 fixed https://jenkins.io/security/advisory/2018-07-30/#SECURITY-1016
 # 1.12.8 fixed the https://issues.jenkins-ci.org/browse/JENKINS-53260 we introduced
 kubernetes:1.12.8
-
-# fabric8 openshift sync
-openshift-sync:1.0.41
 
 # we leverage this plugin in the openshift-client DSL groovy shim
 lockable-resources:2.5
@@ -41,6 +41,8 @@ lockable-resources:2.5
 # processed sec adv https://jenkins.io/security/advisory/2019-05-31/
 # processed sec adv https://jenkins.io/security/advisory/2019-06-11/
 # processed sec adv https://jenkins.io/security/advisory/2019-07-31/
+# processed sec adv https://jenkins.io/security/advisory/2019-08-28/
+
 #
 htmlpublisher:1.16
 mailer:1.21


### PR DESCRIPTION
Bumps the version of the openshift-login-plugin to 1.0.20 which bring fixes and enhancement to OCP 4.1 and 4.2.
