### PR TITLE
Allow use of podman or buildah by using the BUILD_COMMAND variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ subscribed RHEL machine.
     $ make build TARGET=rhel7 VERSION=2
     ```
 
+You can also run the build using Podman. However, e2e tests does not run  
+with Podman (which is the default).
+    ```
+    $ make build TARGET=rhel7 VERSION=2 BUILT_COMMAND="podman build"
+    ```
+
 Also note, as of 3.11, the RHEL images are hosted at registry.redhat.io as well.  This is the terms based
 registry and requires credentials for access.  See [Transitioning the Red Hat container registry](https://www.redhat.com/en/blog/transitioning-red-hat-container-registry) for details:
 * registry.redhat.io/openshift3/jenkins-2-rhel7:v3.11

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -14,6 +14,7 @@ VERSION=$2
 DOCKERFILE_PATH=""
 BASE_IMAGE_NAME="docker.io/openshift/jenkins"
 RHEL_BASE_IMAGE_NAME="registry.access.redhat.com/openshift3/jenkins"
+BUILD_WITH=${BUILD_COMMAND:="docker build"} # other possible values: "podman build --no-cache" or "buildah bud" 
 
 # Cleanup the temporary Dockerfile created by docker build with version
 trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT
@@ -25,8 +26,14 @@ function docker_build_with_version {
   DOCKERFILE_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' $dockerfile)
   cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
   git_version=$(git rev-parse --short HEAD)
+  echo "==============================================================================="
+  echo "| Building image:      "
+  echo "| $DOCKERFILE_PATH     "
+  echo "| for $OS              "
+  echo "| using \"$BUILD_WITH\""
+  echo "================================= START ======================================="
   echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
-  docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
+  ${BUILD_WITH} -t ${IMAGE_NAME} -f "${dockerfile}.version" .
   rm -f "${DOCKERFILE_PATH}.version"
 }
 


### PR DESCRIPTION
This is required to allow: 
- build with RHEL8 (which has not docker anymore)
- build multistage to get rid of dumb-init

/assign @waveywaves
/assign @gabemontero
