### PR TITLE
Format logs

### DIFF
--- a/2/contrib/openshift/configuration/logging.properties
+++ b/2/contrib/openshift/configuration/logging.properties
@@ -1,0 +1,5 @@
+# Jenkins logging configuration for OpenShift
+
+.level=INFO
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-7s %2$s %5$s%6$s%n

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -522,7 +522,9 @@ fi
 if [[ -z "${JENKINS_JAVA_OPTIONS}" ]]; then
     # a discover was made upstream that if the monitor plugin is installed, it creates httpsession's via its filter, which impact the login plugin bearer token support,
     # so the displayed-counters setting turns that off
-    JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS -Dfile.encoding=UTF8 -Djavamelody.displayed-counters=log,error $JENKINS_ACCESSLOG $FATAL_ERROR_OPTION"
+    JENKINS_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS "
+    JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS -Dfile.encoding=UTF8 -Djavamelody.displayed-counters=log,error $JENKINS_ACCESSLOG $FATAL_ERROR_OPTION"
+    JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS -Djava.util.logging.config.file=$JENKINS_HOME/logging.properties"
 fi
 
 JAVA_HTTP_PROXY_OPTIONS="-Djdk.http.auth.tunneling.disabledSchemes= -Djdk.http.auth.proxying.disabledSchemes="


### PR DESCRIPTION
Format logs in the console to be more readable

example
```
2019-10-29 15:34:19 INFO     jenkins.InitReactorRunner$1 onAttained Augmented all extensions
2019-10-29 15:34:19 INFO     jenkins.InitReactorRunner$1 onAttained Loaded all jobs
```