### PR TITLE
Force workspace volume to be emptyDir by default for pod templates

### DIFF
--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -88,6 +88,9 @@ function generate_kubernetes_config() {
           <label>maven</label>
           <serviceAccount>${oc_serviceaccount_name}</serviceAccount>
           <nodeSelector></nodeSelector>
+          <workspaceVolume class="org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.EmptyDirWorkspaceVolume">
+            <memory>false</memory>
+          </workspaceVolume>
           <volumes/>
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
@@ -119,6 +122,9 @@ function generate_kubernetes_config() {
           <label>nodejs</label>
           <serviceAccount>${oc_serviceaccount_name}</serviceAccount>
           <nodeSelector></nodeSelector>
+          <workspaceVolume class="org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.EmptyDirWorkspaceVolume">
+            <memory>false</memory>
+          </workspaceVolume>
           <volumes/>
           <containers>
             <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -10,7 +10,8 @@ openshift-sync:1.0.42
 # 1.12.0 fixed https://jenkins.io/security/advisory/2018-07-30/#SECURITY-1016
 # 1.12.8 fixed the https://issues.jenkins-ci.org/browse/JENKINS-53260 we introduced
 # 1.18.2 upgrade to support OpenJdk11
-kubernetes:1.18.2
+# 1.19.3 Support dynamic workspace volumes
+kubernetes:1.19.3
 credentials:2.2.0
 docker-commons:1.14
 pipeline-model-definition:1.3.7


### PR DESCRIPTION
- In some cases, it is possible for the workspace volume to be set as a DynamicPVCWorkspaceVolume when
  the pod template is persisted when no workspace volume is specified.
- Some environments may not permit PVCs to be created on the fly and this can then result in:

```
Error in provisioning; agent=KubernetesSlave name: maven-q74tc, 
template=PodTemplate{inheritFrom='', name='maven', namespace='', label='maven', 
serviceAccount='jenkins', nodeSelector='', nodeUsageMode=NORMAL, 
workspaceVolume=org.csanchez.jenkins.plugins.kubernetes.volumes.workspace.DynamicPVCWorkspaceVolume@61839d72, containers=[ContainerTemplate{name='jnlp', 
image='docker.io/openshift/jenkins-agent-maven-35-centos7:v3.11', alwaysPullImage=true, 
workingDir='/tmp', command='', args='${computer.jnlpmac} ${computer.name}', 
resourceRequestCpu='', resourceRequestMemory='', resourceLimitCpu='', resourceLimitMemory='', 
livenessProbe=org.csanchez.jenkins.plugins.kubernetes.ContainerLivenessProbe@556c26f6}]}

io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: 
https://172.30.0.1/api/v1/namespaces/cvp/persistentvolumeclaims. Message: Forbidden!Configured 
service account doesn't have access. Service account may have been revoked. 
persistentvolumeclaims "pvc-maven-q74tc" is forbidden: cannot set blockOwnerDeletion if an 
ownerReference refers to a resource you can't set finalizers on: no RBAC policy matched, <nil>.

```