### PR TITLE
Bug 1793323: Remove the use of  /etc/passwd in favor of cri-o

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -62,7 +62,6 @@ ADD release.version /tmp/release.version
 
 RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.txt "--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-fast-datapath-beta --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
     rmdir /var/log/jenkins && \
-    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -73,7 +73,6 @@ ADD release.version /tmp/release.version
 
 RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.txt && \
     rmdir /var/log/jenkins && \
-    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/2/contrib/jenkins/jenkins-common.sh
+++ b/2/contrib/jenkins/jenkins-common.sh
@@ -9,18 +9,6 @@ export AUTH_TOKEN=${KUBE_SA_DIR}/token
 export JENKINS_PASSWORD KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
 export ITEM_ROOTDIR="\${ITEM_ROOTDIR}" # Preserve this variable Jenkins has in config.xml
 
-# Generate passwd file based on current uid
-function generate_passwd_file() {
-  USER_ID=$(id -u)
-  GROUP_ID=$(id -g)
-
-  if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"997" ]; then
-
-    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd
-
-  fi
-}
-
 # Takes a password and an optional salt value, outputs the hashed password.
 function obfuscate_password {
     local password="$1"

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -316,10 +316,6 @@ if [[ "${CONTAINER_CORE_LIMIT}" ]]; then
   JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMIT} -XX:CICompilerCount=2"
 fi
 
-# Since OpenShift runs this Docker image under random user ID, we have to assign
-# the 'jenkins' user name to this UID.
-generate_passwd_file
-
 mkdir /tmp/war
 unzip -q /usr/lib/jenkins/jenkins.war -d /tmp/war
 if [ -e ${JENKINS_HOME}/password ]; then

--- a/HACKING.md
+++ b/HACKING.md
@@ -24,9 +24,7 @@ Be sure that you are logged-in with an OpenShift cluster or that KUBECONFIG envi
 ### Building on an OpenShift cluster
 
 ```
-current_branch=$( git rev-parse --abbrev-ref HEAD )
-oc new-build 
-oc patch bc jenkins --patch='{ "spec" : { "strategy" : { "dockerStrategy" : { "dockerfilePath" : "Dockerfile.localdev" }} , "source" : { "git" : { "ref" : "$current_branch"  }}}}}'
+oc new-build https://github.com/origin/jenkins.git#your-branch-name --context-dir=2/
 ```
 
 ### Deploying on an OpenShift Cluster

--- a/agent-maven-3.5/Dockerfile
+++ b/agent-maven-3.5/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/agent-maven-3.5/Dockerfile.localdev
+++ b/agent-maven-3.5/Dockerfile.localdev
@@ -7,7 +7,10 @@ ENV MAVEN_VERSION=3.5 \
     ENV=/usr/local/bin/scl_enable \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    MAVEN_OPTS="-Duser.home=$HOME"
+# TODO: Remove MAVEN_OPTS env once cri-o pushes the $HOME variable in /etc/passwd
+
 # Install Maven
 RUN INSTALL_PKGS="java-11-openjdk-devel.x86_64 java-1.8.0-openjdk-devel.x86_64 maven*" && \
     curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \

--- a/agent-maven-3.5/Dockerfile.rhel7
+++ b/agent-maven-3.5/Dockerfile.rhel7
@@ -15,7 +15,9 @@ ENV MAVEN_VERSION=3.5 \
     ENV=/usr/local/bin/scl_enable \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    MAVEN_OPTS="-Duser.home=$HOME"
+# TODO: Remove MAVEN_OPTS env once cri-o pushes the $HOME variable in /etc/passwd
 
 # Install Maven
 RUN INSTALL_PKGS="java-11-openjdk-devel java-1.8.0-openjdk-devel rh-maven35*" && \

--- a/agent-nodejs-10/Dockerfile
+++ b/agent-nodejs-10/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/agent-nodejs-8/Dockerfile
+++ b/agent-nodejs-8/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/slave-base/Dockerfile
+++ b/slave-base/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -31,7 +31,6 @@ RUN curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \
-    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -36,7 +36,6 @@ RUN INSTALL_PKGS="bc gettext git java-11-openjdk-headless java-1.8.0-openjdk-hea
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \
-    chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \

--- a/slave-base/contrib/bin/generate_container_user
+++ b/slave-base/contrib/bin/generate_container_user
@@ -1,9 +1,0 @@
-# Set current user in nss_wrapper
-USER_ID=$(id -u)
-GROUP_ID=$(id -g)
-
-if [ x"$USER_ID" != x"0" ]; then
-
-    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> /etc/passwd
-
-fi

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -169,7 +169,7 @@ if [[ $(echo "$@" | awk '{print NF}') -gt 1 ]]; then
   read -a JNLP_JAVA_OVERRIDES_ARRAY <<< "$JNLP_JAVA_OVERRIDES"
 
   set -x
-  cd ${JENKINS_DIR} && exec java $JNLP_JAVA_OPTIONS \
+  cd ${JENKINS_DIR} && exec java -Duser.home=${HOME} $JNLP_JAVA_OPTIONS \
                                  "${JNLP_JAVA_OVERRIDES_ARRAY[@]}" \
                                  -cp $JAR hudson.remoting.jnlp.Main \
                                  -headless $PARAMS "$@"

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -15,8 +15,6 @@ export HOME=${JENKINS_HOME}
 
 export JAVA_VERSION=${USE_JAVA_VERSION:=java-11}
 
-source /usr/local/bin/generate_container_user
-
 CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 


### PR DESCRIPTION
cri-o automatically appends the arbitrary user assigned by openshift to /etc/passwd.
/etc/passwd doesn't have to be group writable then, neither we need nss_wrapper.

This PR removes the use of both for 4.2+
