### PR TITLE
Use OpenJDK 11 on s390x [4.2]

### DIFF
--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -46,7 +46,8 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images 
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \
+    JDK_VER=$(if [ "$(uname -m)" == "s390x" ]; then echo -n 11; else echo -n 1.8.0; fi) && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 dumb-init  java-$JDK_VER-openjdk java-$JDK_VER-openjdk-devel" && \
     yum install -y $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all  && \


### PR DESCRIPTION
OpenJDK 8 does not have JIT enabled on s390x, and Jenkins has moved
unconditionally to OpenJDK 11 in 4.3.