### PR TITLE
Bug 1971537: Support cgroups v2

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -238,8 +238,33 @@ function get_java_proxy_config() {
   echo $config
 }
 
+function linux_available_memory_bytes() {
+  local kbytes
+  kbytes=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
+  echo $((kbytes*(2**10)))
+}
 
-CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+function container_max_memory_bytes() {
+  local limit
+  if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    # cgroups v1
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+    return
+  fi
+  if [ -f /sys/fs/cgroup/memory.max ]; then
+    # cgroups v2
+    limit=$(cat /sys/fs/cgroup/memory.max)
+    if [ "${limit}" == 'max' ]; then
+      linux_available_memory_bytes
+      return
+    fi
+    echo $limit
+    return
+  fi
+  linux_available_memory_bytes
+}
+
+CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
 # TODO once bz-1784147 is fixed, we can set default version to USE_JAVA_VERSION:=java-11

--- a/agent-maven-3.5/contrib/bin/configure-agent
+++ b/agent-maven-3.5/contrib/bin/configure-agent
@@ -86,6 +86,32 @@ if [ -n "$MAVEN_MIRROR_URL" ]; then
   sed -i "s|<!-- ### configured mirrors ### -->|$xml|" $HOME/.m2/settings.xml
 fi
 
-CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+function linux_available_memory_bytes() {
+  local kbytes
+  kbytes=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
+  echo $((kbytes*(2**10)))
+}
+
+function container_max_memory_bytes() {
+  local limit
+  if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    # cgroups v1
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+    return
+  fi
+  if [ -f /sys/fs/cgroup/memory.max ]; then
+    # cgroups v2
+    limit=$(cat /sys/fs/cgroup/memory.max)
+    if [ "${limit}" == 'max' ]; then
+      linux_available_memory_bytes
+      return
+    fi
+    echo $limit
+    return
+  fi
+  linux_available_memory_bytes
+}
+
+CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -15,7 +15,33 @@ export HOME=${JENKINS_HOME}
 
 export JAVA_VERSION=${USE_JAVA_VERSION:=java-11}
 
-CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+function linux_available_memory_bytes() {
+  local kbytes
+  kbytes=$(cat /proc/meminfo | grep MemAvailable | awk '{print $2}')
+  echo $((kbytes*(2**10)))
+}
+
+function container_max_memory_bytes() {
+  local limit
+  if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    # cgroups v1
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+    return
+  fi
+  if [ -f /sys/fs/cgroup/memory.max ]; then
+    # cgroups v2
+    limit=$(cat /sys/fs/cgroup/memory.max)
+    if [ "${limit}" == 'max' ]; then
+      linux_available_memory_bytes
+      return
+    fi
+    echo $limit
+    return
+  fi
+  linux_available_memory_bytes
+}
+
+CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
 if [[ "$(uname -m)" == "x86_64" ]]; then


### PR DESCRIPTION
In code there are embedded paths that are valid only for cgroups v1. This PR creates functions that calculate memory in container either for v1 or v2 of cgroups.