### PR TITLE
Bug 1810429: Bump login plugin to 1.0.23

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,6 +1,6 @@
 
 # OpenShift Plugins
-openshift-login:1.0.22
+openshift-login:1.0.23
 openshift-client:1.0.32
 openshift-sync:1.0.44
 


### PR DESCRIPTION
`openshift-login` plugin has been updated to 1.0.23 which contians fix for Bugzilla 1810429