### PR TITLE
Bug 1810393: 4.1  2.204.2 and plugins updates

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.localdev

--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -1,16 +1,18 @@
+##############################################
+# Stage 1 : Build go-init
+##############################################
+FROM openshift/origin-release:golang-1.12 AS go-init-builder
+WORKDIR  /go/src/github.com/openshift/jenkins
+COPY . .
+WORKDIR  /go/src/github.com/openshift/jenkins/go-init
+RUN go build . && cp go-init /usr/bin
+
+##############################################
+# Stage 2 : Build slave-base with go-init
+##############################################
 FROM quay.io/openshift/origin-cli
-
-# Jenkins image for OpenShift
-#
-# This image provides a Jenkins server, primarily intended for integration with
-# OpenShift v3.
-#
-# Volumes:
-# * /var/jenkins_home
-# Environment:
-# * $JENKINS_PASSWORD - Password for the Jenkins 'admin' user.
-
-MAINTAINER Ben Parees <bparees@redhat.com>
+MAINTAINER Akram Ben Aissi <abenaiss@redhat.com>
+COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 
 # Jenkins LTS packages from
 # https://pkg.jenkins.io/redhat-stable/
@@ -27,17 +29,18 @@ LABEL k8s.io.description="Jenkins is a continuous integration server" \
       k8s.io.display-name="Jenkins 2" \
       openshift.io.expose-services="8080:http" \
       openshift.io.tags="jenkins,jenkins2,ci" \
+      io.jenkins.version="2.204.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # 8080 for main web interface, 50000 for slave agents
 EXPOSE 8080 50000
 
-RUN curl https://copr.fedorainfracloud.org/coprs/alsadi/dumb-init/repo/epel-7/alsadi-dumb-init-epel-7.repo -o /etc/yum.repos.d/alsadi-dumb-init-epel-7.repo && \
-    curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \
+RUN curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \
     curl http://mirror.centos.org/centos-7/7/os/x86_64/RPM-GPG-KEY-CentOS-7 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-1.8.0-openjdk java-1.8.0-openjdk-devel" && \
-    DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
-    yum $DISABLES -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel jq " && \
+    DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-fast-datapath-beta --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
+    yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install epel-release && \
+    yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8
@@ -47,7 +50,7 @@ COPY ./contrib/jenkins /usr/local/bin
 ADD ./contrib/s2i /usr/libexec/s2i
 ADD release.version /tmp/release.version
 
-RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.txt "--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
+RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.txt "--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-fast-datapath --disablerepo=rhel-fast-datapath-beta --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
     rmdir /var/log/jenkins && \
     chmod 664 /etc/passwd && \
     chmod -R 775 /etc/alternatives && \
@@ -61,25 +64,16 @@ RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.t
     unlink /usr/bin/java && \
     unlink /usr/bin/jjs && \
     unlink /usr/bin/keytool && \
-    unlink /usr/bin/orbd && \
     unlink /usr/bin/pack200 && \
-    unlink /usr/bin/policytool && \
     unlink /usr/bin/rmid && \
     unlink /usr/bin/rmiregistry && \
-    unlink /usr/bin/servertool && \
-    unlink /usr/bin/tnameserv && \
     unlink /usr/bin/unpack200 && \
-    unlink /usr/lib/jvm-exports/jre && \
     unlink /usr/share/man/man1/java.1.gz && \
     unlink /usr/share/man/man1/jjs.1.gz && \
     unlink /usr/share/man/man1/keytool.1.gz && \
-    unlink /usr/share/man/man1/orbd.1.gz && \
     unlink /usr/share/man/man1/pack200.1.gz && \
-    unlink /usr/share/man/man1/policytool.1.gz && \
     unlink /usr/share/man/man1/rmid.1.gz && \
     unlink /usr/share/man/man1/rmiregistry.1.gz && \
-    unlink /usr/share/man/man1/servertool.1.gz && \
-    unlink /usr/share/man/man1/tnameserv.1.gz && \
     unlink /usr/share/man/man1/unpack200.1.gz && \
     chown -R 1001:0 /opt/openshift && \
     /usr/local/bin/fix-permissions /opt/openshift && \
@@ -90,5 +84,5 @@ RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.t
 VOLUME ["/var/lib/jenkins"]
 
 USER 1001
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["/usr/libexec/s2i/run"]
+ENTRYPOINT ["/usr/bin/go-init", "-main", "/usr/libexec/s2i/run"]
+

--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -11,8 +11,8 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == "false" ]]; then
     if [ "$#" == "1" ]; then
         YUM_FLAGS="$1"
     fi
-    yum -y $YUM_FLAGS --setopt=tsflags=nodocs install jenkins-2.176.3-1.1
-    rpm -V jenkins-2.176.3-1.1
+    yum -y $YUM_FLAGS --setopt=tsflags=nodocs install jenkins-2.204.2-1.1
+    rpm -V jenkins-2.204.2-1.1
     yum clean all
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,15 +1,19 @@
 
 # OpenShift Plugins
-openshift-login:1.0.20
+openshift-login:1.0.23
 openshift-client:1.0.32
-openshift-sync:1.0.41
+openshift-sync:1.0.44
 
 
 # kubernetes plugin - https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
 # 1.7.1 fixed https://jenkins.io/security/advisory/2018-06-04/#SECURITY-883
 # 1.12.0 fixed https://jenkins.io/security/advisory/2018-07-30/#SECURITY-1016
 # 1.12.8 fixed the https://issues.jenkins-ci.org/browse/JENKINS-53260 we introduced
-kubernetes:1.12.8
+# 1.18.2 upgrade to support OpenJdk11
+kubernetes:1.18.2
+credentials:2.2.0
+docker-commons:1.14
+pipeline-model-definition:1.3.7
 
 # we leverage this plugin in the openshift-client DSL groovy shim
 lockable-resources:2.5
@@ -45,19 +49,20 @@ lockable-resources:2.5
 # processed sec adv https://jenkins.io/security/advisory/2019-10-01/#SECURITY-1590
 #
 
-htmlpublisher:1.21
-mailer:1.21
 config-file-provider:3.5
-docker-commons:1.11
+htmlpublisher:1.21
 job-dsl:1.72
+mailer:1.21
 parameterized-trigger:2.35.2
 pipeline-build-step:2.7
 pipeline-input-step:2.8
-credentials:2.1.19 
 script-security:1.66
 
-credentials-binding:1.19
+ant:1.10
+pam-auth:1.6
+git-client:3.0.0
 
+credentials-binding:1.19
 junit:1.26.1
 workflow-support:2.18
 git:3.9.3
@@ -67,7 +72,6 @@ github:1.29.2
 github-branch-source:2.3.6
 workflow-cps:2.73
 workflow-cps-global-lib:2.15
-pipeline-model-definition:1.3.4.1
 token-macro:2.8
 workflow-remote-loader:1.5
 
@@ -75,7 +79,7 @@ workflow-remote-loader:1.5
 mapdb-api:1.0.9.0
 
 matrix-project:1.14
-ssh-credentials:1.14
+ssh-credentials:1.17.2
 
 # Pipeline Utility Steps Plugin - https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Utility+Steps+Plugin
 pipeline-utility-steps:2.1.0
@@ -94,3 +98,8 @@ blueocean:1.10.2
 # 2.5 now includes pipeline-model-definition (declaritive pipeline)
 # 2.4 brought in pipeline-milestone-step
 workflow-aggregator:2.6
+
+# Monitoring plugins
+metrics:4.0.2.5
+prometheus:2.0.0
+

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -170,13 +170,16 @@ function force_copy_plugins() {
 CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
+# TODO once bz-1784147 is fixed, we can set default version to USE_JAVA_VERSION:=java-11
+export JAVA_VERSION=${USE_JAVA_VERSION:=java-1.8.0}
+
 if [[ "$(uname -m)" == "x86_64" ]]; then
-	alternatives --set java $(alternatives --display java | awk '/family.*x86_64/ { print $1; }')
-	alternatives --set javac $(alternatives --display javac | awk '/family.*x86_64/ { print $1; }')
+	alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
+	alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
 #set JVM for all other archs
 else
-  alternatives --set java $(alternatives --display java | awk '/family.*'$(uname -m)'/ { print $1; }')
-  alternatives --set javac $(alternatives --display javac | awk '/family.*'$(uname -m)'/ { print $1; }')
+  alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
+  alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
 fi
 
 echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"

--- a/2/go-init/Dockerfile
+++ b/2/go-init/Dockerfile
@@ -1,0 +1,14 @@
+###########################################
+# Stage 1: Build go-init
+###########################################
+
+FROM openshift/origin-release:golang-1.12 AS builder
+COPY ./ /go/src/go-init 
+RUN go install go-init
+
+###########################################
+# Stage 2: ubi-minimal image with go-init
+###########################################
+
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+COPY --from=builder /go/bin/go-init /usr/bin/go-init

--- a/2/go-init/LICENSE
+++ b/2/go-init/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Pablo RUTH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/2/go-init/README.md
+++ b/2/go-init/README.md
@@ -1,0 +1,66 @@
+# go-init
+
+**go-init** is a minimal init system with simple *lifecycle management* heavily inspired by [dumb-init](https://github.com/Yelp/dumb-init).
+
+It is designed to run as the first process (PID 1) inside a container.
+
+It is lightweight (less than 500KB after UPX compression) and statically linked so you don't need to install any dependency.
+
+## Download
+
+You can download the latest version on [releases page](https://github.com/pablo-ruth/go-init/releases)
+
+## Why you need an init system
+
+I can't explain it better than Yelp in *dumb-init* repo, so please [read their explanation](https://github.com/Yelp/dumb-init/blob/v1.2.0/README.md#why-you-need-an-init-system)
+
+Summary:
+- Proper signal forwarding
+- Orphaned zombies reaping
+
+## Why another minimal init system
+
+In addition to *init* problematic, **go-init** tries to solve another Docker flaw by adding *hooks* on start and stop of the main process.
+
+If you want to launch a command before the main process of your container and another one after the main process exit, you can't with Docker, see [issue 6982](https://github.com/moby/moby/issues/6982)
+
+With **go-init** you can do that with "pre" and "post" hooks.
+
+## Usage
+
+### one command
+
+```
+$ go-init -main "my_command param1 param2"
+```
+
+### pre-start and post-stop hooks
+
+```
+$ go-init -pre "my_pre_command param1" -main "my_command param1 param2" -post "my_post_command param1"
+```
+
+## docker
+
+Example of Dockerfile using *go-init*:
+```
+FROM alpine:latest
+
+COPY go-init /bin/go-init
+
+RUN chmod +x /bin/go-init
+
+ENTRYPOINT ["go-init"]
+
+CMD ["-pre", "echo hello world", "-main", "sleep 5", "-post", "echo I finished my sleep bye"]
+```
+
+Build it:
+```
+docker build -t go-init-example
+```
+
+Run it:
+```
+docker run go-init-example
+```

--- a/2/go-init/main.go
+++ b/2/go-init/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	versionString = "undefined"
+)
+
+func main() {
+	var preStartCmd string
+	var mainCmd string
+	var postStopCmd string
+	var version bool
+
+	flag.StringVar(&preStartCmd, "pre", "", "Pre-start command")
+	flag.StringVar(&mainCmd, "main", "", "Main command")
+	flag.StringVar(&postStopCmd, "post", "", "Post-stop command")
+	flag.BoolVar(&version, "version", false, "Display go-init version")
+	flag.Parse()
+
+	if version {
+		fmt.Println(versionString)
+		os.Exit(0)
+	}
+
+	if mainCmd == "" {
+		log.Fatal("[go-init] No main command defined, exiting")
+	}
+
+	// Routine to reap zombies (it's the job of init)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go removeZombies(ctx, &wg)
+
+	// Launch pre-start command
+	if preStartCmd == "" {
+		log.Println("[go-init] No pre-start command defined, skip")
+	} else {
+		log.Printf("[go-init] Pre-start command launched : %s\n", preStartCmd)
+		err := run(preStartCmd)
+		if err != nil {
+			log.Println("[go-init] Pre-start command failed")
+			log.Printf("[go-init] %s\n", err)
+			cleanQuit(cancel, &wg, 1)
+		} else {
+			log.Printf("[go-init] Pre-start command exited")
+		}
+	}
+
+	// Launch main command
+	var mainRC int
+	log.Printf("[go-init] Main command launched : %s\n", mainCmd)
+	err := run(mainCmd)
+	if err != nil {
+		log.Println("[go-init] Main command failed")
+		log.Printf("[go-init] %s\n", err)
+		mainRC = 1
+	} else {
+		log.Printf("[go-init] Main command exited")
+	}
+
+	// Launch post-stop command
+	if postStopCmd == "" {
+		log.Println("[go-init] No post-stop command defined, skip")
+	} else {
+		log.Printf("[go-init] Post-stop command launched : %s\n", postStopCmd)
+		err := run(postStopCmd)
+		if err != nil {
+			log.Println("[go-init] Post-stop command failed")
+			log.Printf("[go-init] %s\n", err)
+			cleanQuit(cancel, &wg, 1)
+		} else {
+			log.Printf("[go-init] Post-stop command exited")
+		}
+	}
+
+	// Wait removeZombies goroutine
+	cleanQuit(cancel, &wg, mainRC)
+}
+
+func removeZombies(ctx context.Context, wg *sync.WaitGroup) {
+	for {
+		var status syscall.WaitStatus
+
+		// Wait for orphaned zombie process
+		pid, _ := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+
+		if pid <= 0 {
+			// PID is 0 or -1 if no child waiting
+			// so we wait for 1 second for next check
+			time.Sleep(1 * time.Second)
+		} else {
+			// PID is > 0 if a child was reaped
+			// we immediately check if another one
+			// is waiting
+			continue
+		}
+
+		// Non-blocking test
+		// if context is done
+		select {
+		case <-ctx.Done():
+			// Context is done
+			// so we stop goroutine
+			wg.Done()
+			return
+		default:
+		}
+	}
+}
+
+func run(command string) error {
+
+	var commandStr string
+	var argsSlice []string
+
+	// Split cmd and args
+	commandSlice := strings.Fields(command)
+	commandStr = commandSlice[0]
+	// if there is args
+	if len(commandSlice) > 1 {
+		argsSlice = commandSlice[1:]
+	}
+
+	// Register chan to receive system signals
+	sigs := make(chan os.Signal, 1)
+	defer close(sigs)
+	signal.Notify(sigs)
+	defer signal.Reset()
+
+	// Define command and rebind
+	// stdout and stdin
+	cmd := exec.Command(commandStr, argsSlice...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Create a dedicated pidgroup
+	// used to forward signals to
+	// main process and all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Goroutine for signals forwarding
+	go func() {
+		for sig := range sigs {
+			// Ignore SIGCHLD signals since
+			// thez are only usefull for go-init
+			if sig != syscall.SIGCHLD {
+				// Forward signal to main process and all children
+				syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
+			}
+		}
+	}()
+
+	// Start defined command
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// Wait for command to exit
+	err = cmd.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cleanQuit(cancel context.CancelFunc, wg *sync.WaitGroup, code int) {
+	// Signal zombie goroutine to stop
+	// and wait for it to release waitgroup
+	cancel()
+	wg.Wait()
+
+	os.Exit(code)
+}

--- a/agent-maven-3.5/Dockerfile.localdev
+++ b/agent-maven-3.5/Dockerfile.localdev
@@ -7,7 +7,8 @@ ENV MAVEN_VERSION=3.5 \
     BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \
     PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
-    PATH=$PATH:/opt/gradle/bin
+    PATH=$PATH:/opt/gradle/bin \
+    MAVEN_OPTS="-Duser.home=$HOME"
 
 # Install Maven
 RUN INSTALL_PKGS="java-1.8.0-openjdk-devel.x86_64 maven*" && \

--- a/agent-maven-3.5/Dockerfile.rhel7
+++ b/agent-maven-3.5/Dockerfile.rhel7
@@ -13,7 +13,8 @@ LABEL com.redhat.component="jenkins-agent-maven-35-rhel7-container" \
 ENV MAVEN_VERSION=3.5 \
     BASH_ENV=/usr/local/bin/scl_enable \
     ENV=/usr/local/bin/scl_enable \
-    PROMPT_COMMAND=". /usr/local/bin/scl_enable"
+    PROMPT_COMMAND=". /usr/local/bin/scl_enable" \
+    MAVEN_OPTS="-Duser.home=$HOME"
 
 # Install Maven
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -1,23 +1,37 @@
+##############################################
+# Stage 1 : Build go-init
+##############################################
+FROM openshift/origin-release:golang-1.12 AS go-init-builder
+WORKDIR  /go/src/github.com/openshift/jenkins
+COPY . .
+WORKDIR  /go/src/github.com/openshift/jenkins/go-init
+RUN go build . && cp go-init /usr/bin
+
+##############################################
+# Stage 2 : Build slave-base with go-init
+##############################################
 FROM quay.io/openshift/origin-cli
+MAINTAINER Akram Ben Aissi <abenaiss@redhat.com>
+COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 
-MAINTAINER Ben Parees <bparees@redhat.com>
-
-ENV HOME=/home/jenkins
+ENV HOME=/home/jenkins \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
 
 USER root
 # Install headless Java
-RUN curl https://copr.fedorainfracloud.org/coprs/alsadi/dumb-init/repo/epel-7/alsadi-dumb-init-epel-7.repo -o /etc/yum.repos.d/alsadi-dumb-init-epel-7.repo && \
-    curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \
+RUN curl https://raw.githubusercontent.com/cloudrouter/centos-repo/master/CentOS-Base.repo -o /etc/yum.repos.d/CentOS-Base.repo && \
     curl http://mirror.centos.org/centos-7/7/os/x86_64/RPM-GPG-KEY-CentOS-7 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2" && \
+    INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 " && \
     DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
+    yum $DISABLES install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager epel-release && \
     yum $DISABLES install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
-    chmod -R g+w /home/jenkins && \
     chmod 664 /etc/passwd && \
+    chmod -R g+w /home/jenkins && \
     chmod -R 775 /etc/alternatives && \
     chmod -R 775 /var/lib/alternatives && \
     chmod -R 775 /usr/lib/jvm && \
@@ -54,4 +68,5 @@ RUN curl https://copr.fedorainfracloud.org/coprs/alsadi/dumb-init/repo/epel-7/al
 ADD contrib/bin/* /usr/local/bin/
 
 # Run the Jenkins JNLP client
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/usr/local/bin/run-jnlp-client"]
+ENTRYPOINT ["/usr/bin/go-init", "-main", "/usr/local/bin/run-jnlp-client"]
+

--- a/slave-base/Dockerfile.rhel7
+++ b/slave-base/Dockerfile.rhel7
@@ -17,7 +17,7 @@ USER root
 # Install headless Java
 RUN yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="bc gettext git java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 dumb-init" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \
     mkdir -p /home/jenkins && \

--- a/slave-base/go-init/Dockerfile
+++ b/slave-base/go-init/Dockerfile
@@ -1,0 +1,14 @@
+###########################################
+# Stage 1: Build go-init
+###########################################
+
+FROM openshift/origin-release:golang-1.12 AS builder
+COPY ./ /go/src/go-init 
+RUN go install go-init
+
+###########################################
+# Stage 2: ubi-minimal image with go-init
+###########################################
+
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+COPY --from=builder /go/bin/go-init /usr/bin/go-init

--- a/slave-base/go-init/LICENSE
+++ b/slave-base/go-init/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Pablo RUTH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/slave-base/go-init/README.md
+++ b/slave-base/go-init/README.md
@@ -1,0 +1,66 @@
+# go-init
+
+**go-init** is a minimal init system with simple *lifecycle management* heavily inspired by [dumb-init](https://github.com/Yelp/dumb-init).
+
+It is designed to run as the first process (PID 1) inside a container.
+
+It is lightweight (less than 500KB after UPX compression) and statically linked so you don't need to install any dependency.
+
+## Download
+
+You can download the latest version on [releases page](https://github.com/pablo-ruth/go-init/releases)
+
+## Why you need an init system
+
+I can't explain it better than Yelp in *dumb-init* repo, so please [read their explanation](https://github.com/Yelp/dumb-init/blob/v1.2.0/README.md#why-you-need-an-init-system)
+
+Summary:
+- Proper signal forwarding
+- Orphaned zombies reaping
+
+## Why another minimal init system
+
+In addition to *init* problematic, **go-init** tries to solve another Docker flaw by adding *hooks* on start and stop of the main process.
+
+If you want to launch a command before the main process of your container and another one after the main process exit, you can't with Docker, see [issue 6982](https://github.com/moby/moby/issues/6982)
+
+With **go-init** you can do that with "pre" and "post" hooks.
+
+## Usage
+
+### one command
+
+```
+$ go-init -main "my_command param1 param2"
+```
+
+### pre-start and post-stop hooks
+
+```
+$ go-init -pre "my_pre_command param1" -main "my_command param1 param2" -post "my_post_command param1"
+```
+
+## docker
+
+Example of Dockerfile using *go-init*:
+```
+FROM alpine:latest
+
+COPY go-init /bin/go-init
+
+RUN chmod +x /bin/go-init
+
+ENTRYPOINT ["go-init"]
+
+CMD ["-pre", "echo hello world", "-main", "sleep 5", "-post", "echo I finished my sleep bye"]
+```
+
+Build it:
+```
+docker build -t go-init-example
+```
+
+Run it:
+```
+docker run go-init-example
+```

--- a/slave-base/go-init/main.go
+++ b/slave-base/go-init/main.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var (
+	versionString = "undefined"
+)
+
+func main() {
+	var preStartCmd string
+	var mainCmd string
+	var postStopCmd string
+	var version bool
+
+	flag.StringVar(&preStartCmd, "pre", "", "Pre-start command")
+	flag.StringVar(&mainCmd, "main", "", "Main command")
+	flag.StringVar(&postStopCmd, "post", "", "Post-stop command")
+	flag.BoolVar(&version, "version", false, "Display go-init version")
+	flag.Parse()
+
+	if version {
+		fmt.Println(versionString)
+		os.Exit(0)
+	}
+
+	if mainCmd == "" {
+		log.Fatal("[go-init] No main command defined, exiting")
+	}
+
+	// Routine to reap zombies (it's the job of init)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go removeZombies(ctx, &wg)
+
+	// Launch pre-start command
+	if preStartCmd == "" {
+		log.Println("[go-init] No pre-start command defined, skip")
+	} else {
+		log.Printf("[go-init] Pre-start command launched : %s\n", preStartCmd)
+		err := run(preStartCmd)
+		if err != nil {
+			log.Println("[go-init] Pre-start command failed")
+			log.Printf("[go-init] %s\n", err)
+			cleanQuit(cancel, &wg, 1)
+		} else {
+			log.Printf("[go-init] Pre-start command exited")
+		}
+	}
+
+	// Launch main command
+	var mainRC int
+	log.Printf("[go-init] Main command launched : %s\n", mainCmd)
+	err := run(mainCmd)
+	if err != nil {
+		log.Println("[go-init] Main command failed")
+		log.Printf("[go-init] %s\n", err)
+		mainRC = 1
+	} else {
+		log.Printf("[go-init] Main command exited")
+	}
+
+	// Launch post-stop command
+	if postStopCmd == "" {
+		log.Println("[go-init] No post-stop command defined, skip")
+	} else {
+		log.Printf("[go-init] Post-stop command launched : %s\n", postStopCmd)
+		err := run(postStopCmd)
+		if err != nil {
+			log.Println("[go-init] Post-stop command failed")
+			log.Printf("[go-init] %s\n", err)
+			cleanQuit(cancel, &wg, 1)
+		} else {
+			log.Printf("[go-init] Post-stop command exited")
+		}
+	}
+
+	// Wait removeZombies goroutine
+	cleanQuit(cancel, &wg, mainRC)
+}
+
+func removeZombies(ctx context.Context, wg *sync.WaitGroup) {
+	for {
+		var status syscall.WaitStatus
+
+		// Wait for orphaned zombie process
+		pid, _ := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+
+		if pid <= 0 {
+			// PID is 0 or -1 if no child waiting
+			// so we wait for 1 second for next check
+			time.Sleep(1 * time.Second)
+		} else {
+			// PID is > 0 if a child was reaped
+			// we immediately check if another one
+			// is waiting
+			continue
+		}
+
+		// Non-blocking test
+		// if context is done
+		select {
+		case <-ctx.Done():
+			// Context is done
+			// so we stop goroutine
+			wg.Done()
+			return
+		default:
+		}
+	}
+}
+
+func run(command string) error {
+
+	var commandStr string
+	var argsSlice []string
+
+	// Split cmd and args
+	commandSlice := strings.Fields(command)
+	commandStr = commandSlice[0]
+	// if there is args
+	if len(commandSlice) > 1 {
+		argsSlice = commandSlice[1:]
+	}
+
+	// Register chan to receive system signals
+	sigs := make(chan os.Signal, 1)
+	defer close(sigs)
+	signal.Notify(sigs)
+	defer signal.Reset()
+
+	// Define command and rebind
+	// stdout and stdin
+	cmd := exec.Command(commandStr, argsSlice...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Create a dedicated pidgroup
+	// used to forward signals to
+	// main process and all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	// Goroutine for signals forwarding
+	go func() {
+		for sig := range sigs {
+			// Ignore SIGCHLD signals since
+			// thez are only usefull for go-init
+			if sig != syscall.SIGCHLD {
+				// Forward signal to main process and all children
+				syscall.Kill(-cmd.Process.Pid, sig.(syscall.Signal))
+			}
+		}
+	}()
+
+	// Start defined command
+	err := cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// Wait for command to exit
+	err = cmd.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cleanQuit(cancel context.CancelFunc, wg *sync.WaitGroup, code int) {
+	// Signal zombie goroutine to stop
+	// and wait for it to release waitgroup
+	cancel()
+	wg.Wait()
+
+	os.Exit(code)
+}


### PR DESCRIPTION
This is a catch-up PR as we decided to keep 4.1 because of deprecation.
It adds:
- use of go-init instead of dumb-init that is not resolvable in epel
- use of Jenkins 2.204.2
- use of latest plugins
