### PR TITLE
Bug 1820677: Update Description on Monitored Templates reflecting permission issues

### DIFF
--- a/openshift/templates/jenkins-ephemeral-monitored.json
+++ b/openshift/templates/jenkins-ephemeral-monitored.json
@@ -5,10 +5,10 @@
     "name": "jenkins-ephemeral-monitored",
     "annotations": {
       "openshift.io/display-name": "Jenkins (Ephemeral)",
-      "description": "Jenkins service, without persistent storage.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
+      "description": "Jenkins service, without persistent storage. \n\n To run this template extra RBAC permissions need to be provideed to the use to be able to create the ServiceMonitor Custom Resource managed by the prometheus-operator. \n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
       "iconClass": "icon-jenkins",
       "tags": "instant-app,jenkins",
-      "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.  The Jenkins configuration is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
+      "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login and Prometheus monitoring. DISCLAIMER: User needs to have RBAC Permissions to create the Service Monitor. The Jenkins configuration is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
       "openshift.io/provider-display-name": "Red Hat, Inc.",
       "openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/other_images/jenkins.html",
       "openshift.io/support-url": "https://access.redhat.com"

--- a/openshift/templates/jenkins-persistent-monitored.json
+++ b/openshift/templates/jenkins-persistent-monitored.json
@@ -5,10 +5,10 @@
     "name": "jenkins-persistent-monitored",
     "annotations": {
       "openshift.io/display-name": "Jenkins",
-      "description": "Jenkins service, with persistent storage.\n\nNOTE: You must have persistent volumes available in your cluster to use this template.",
+      "description": "Jenkins service, with persistent storage. \n\n To run this template extra RBAC permissions need to be provideed to the use to be able to create the ServiceMonitor Custom Resource managed by the prometheus-operator. \n\nNOTE: You must have persistent volumes available in your cluster to use this template.",
       "iconClass": "icon-jenkins",
       "tags": "instant-app,jenkins",
-      "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login.",
+      "openshift.io/long-description": "This template deploys a Jenkins server capable of managing OpenShift Pipeline builds and supporting OpenShift-based oauth login and Prometheus monitoring. DISCLAIMER: User needs to have RBAC Permissions to create the Service Monitor.",
       "openshift.io/provider-display-name": "Red Hat, Inc.",
       "openshift.io/documentation-url": "https://docs.okd.io/latest/using_images/other_images/jenkins.html",
       "openshift.io/support-url": "https://access.redhat.com"


### PR DESCRIPTION
To create the Service Monitor custom resource in the Templates,
provided by the Prometheus Operator in Openshift,
users needs specific RBAC permissions to be able to create them.
This necessity needs to be understood by them, hence adding this to the
description of the templates.