### PR TITLE
Bug 1813217: fix maven proxy settings

### DIFF
--- a/agent-maven-3.5/contrib/bin/configure-agent
+++ b/agent-maven-3.5/contrib/bin/configure-agent
@@ -73,7 +73,7 @@ if [ -n "$https_proxy" ]; then
  xml="$xml $proxy"
 fi
 if [ -n "$xml" ]; then
-  sed -i "s|<!-- ### configured http proxy ### -->|$xml|" $HOME/.m2/settings.xml
+  sed -i "s&<!-- ### configured http proxy ### -->&$xml&" $HOME/.m2/settings.xml
 fi
 
 
@@ -83,7 +83,7 @@ if [ -n "$MAVEN_MIRROR_URL" ]; then
     <url>$MAVEN_MIRROR_URL</url>\
     <mirrorOf>external:*</mirrorOf>\
   </mirror>"
-  sed -i "s|<!-- ### configured mirrors ### -->|$xml|" $HOME/.m2/settings.xml
+  sed -i "s&<!-- ### configured mirrors ### -->&$xml&" $HOME/.m2/settings.xml
 fi
 
 CONTAINER_MEMORY_IN_BYTES=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)


### PR DESCRIPTION
The script errors silently, because we are using a sed delimiter that is already present in the no_proxy value
Wondering if may we need set -euxo pipefail on these scripts but i dont want to wake up dameons 

 sed -i 's|<!-- ### configured http proxy ### -->| <proxy>         <id>genhttpproxy</id>         <active>true</active>         <protocol>http</protocol>         <host>*****</host>         <port>3128</port>      <username>*****</username>      <password>***</password>       <nonProxyHosts>*.cluster.local,*.svc|.us-east-2.compute.internal|10.0.0.0/16|10.128.0.0/14|127.0.0.1|169.254.169.254|172.30.0.0/16|api-int.xiuwang-py2.qe.devcluster.openshift.com|etcd-0.xiuwang-py2.qe.devcluster.openshift.com|etcd-1.xiuwang-py2.qe.devcluster.openshift.com|etcd-2.xiuwang-py2.qe.devcluster.openshift.com|localhost|test.no-proxy.com</nonProxyHosts>     </proxy>|' /home/jenkins/.m2/settings.xml
sed: -e expression #1, char 370: unknown option to `s'
