### PR TITLE
Bug 1849094: Use quay.io/openshift/origin-cli:4.2 as base image for upstream

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -10,7 +10,7 @@ RUN go build . && cp go-init /usr/bin
 ##############################################
 # Stage 2 : Build slave-base with go-init
 ##############################################
-FROM quay.io/openshift/origin-cli
+FROM quay.io/openshift/origin-cli:4.2
 MAINTAINER Akram Ben Aissi <abenaiss@redhat.com>
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -10,7 +10,7 @@ RUN go build . && cp go-init /usr/bin
 ##############################################
 # Stage 2 : Build slave-base with go-init
 ##############################################
-FROM quay.io/openshift/origin-cli
+FROM quay.io/openshift/origin-cli:4.2
 MAINTAINER Akram Ben Aissi <abenaiss@redhat.com>
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 


### PR DESCRIPTION
This image contains a version of oc run that still creates
deploymentconfig and this is required by our e2e tests