### PR TITLE
Add Dockerfile.rhel8 throughout

### DIFF
--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -1,0 +1,107 @@
+##############################################
+# Stage 1 : Build go-init
+##############################################
+FROM openshift/origin-release:golang-1.12 AS go-init-builder
+WORKDIR  /go/src/github.com/openshift/jenkins
+COPY . .
+WORKDIR  /go/src/github.com/openshift/jenkins/go-init
+RUN go build . && cp go-init /usr/bin
+
+##############################################
+# Stage 2 : Build slave-base with go-init
+##############################################
+FROM quay.io/openshift/origin-cli
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
+
+# Jenkins image for OpenShift
+#
+# This image provides a Jenkins server, primarily intended for integration with
+# OpenShift v3.
+#
+# Volumes: 
+# * /var/jenkins_home
+# Environment:
+# * $JENKINS_PASSWORD - Password for the Jenkins 'admin' user.
+
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+
+ENV JENKINS_VERSION=2 \
+    HOME=/var/lib/jenkins \
+    JENKINS_HOME=/var/lib/jenkins \
+    JENKINS_UC=https://updates.jenkins.io \
+    OPENSHIFT_JENKINS_IMAGE_VERSION=4.6 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    INSTALL_JENKINS_VIA_RPMS=false
+# openshift/ocp-build-data will change INSTALL_JENKINS_VIA_RPMS to true
+# so that the osbs/brew builds will install via RPMs; when this runs 
+# in api.ci, it will employ the old centos style, download the plugins and
+# redhat-stable core RPM for download
+
+LABEL io.k8s.description="Jenkins is a continuous integration server" \
+      io.k8s.display-name="Jenkins 2" \
+      io.openshift.tags="jenkins,jenkins2,ci" \
+      io.openshift.expose-services="8080:http" \
+      io.jenkins.version="2.222.1" \
+      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="openshift-jenkins-2-container" \
+      name="openshift4/jenkins-2-rhel7" \
+      architecture="x86_64 \
+      maintainer="openshift-dev-services+jenkins@redhat.com""
+
+# 8080 for main web interface, 50000 for slave agents
+EXPOSE 8080 50000
+
+# for backward compatibility with pre-3.6 installs leveraging a PV, where rpm installs went to /usr/lib64/jenkins, we are
+# establishing a symbolic link for that guy as well, so that existing plugins in JENKINS_HOME/plugins pointing to 
+# /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images 
+# do *NOT* have a /usr/lib64/jenkins path
+RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel jq glibc-locale-source" && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V  $INSTALL_PKGS && \
+    yum clean all  && \
+    localedef -f UTF-8 -i en_US en_US.UTF-8
+
+COPY ./contrib/openshift /opt/openshift
+COPY ./contrib/jenkins /usr/local/bin
+ADD ./contrib/s2i /usr/libexec/s2i
+ADD release.version /tmp/release.version
+
+RUN /usr/local/bin/install-jenkins-core-plugins.sh /opt/openshift/base-plugins.txt && \
+    rmdir /var/log/jenkins && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/share/man/man1 && \
+    mkdir -p /var/lib/origin && \
+    chmod 775 /var/lib/origin && \
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz && \
+    chown -R 1001:0 /opt/openshift && \
+    /usr/local/bin/fix-permissions /opt/openshift && \
+    /usr/local/bin/fix-permissions /opt/openshift/configuration/init.groovy.d && \
+    /usr/local/bin/fix-permissions /var/lib/jenkins && \
+    /usr/local/bin/fix-permissions /var/log
+
+VOLUME ["/var/lib/jenkins"]
+
+USER 1001
+ENTRYPOINT ["/usr/bin/go-init", "-main", "/usr/libexec/s2i/run"]
+

--- a/agent-maven-3.5/Dockerfile.rhel8
+++ b/agent-maven-3.5/Dockerfile.rhel8
@@ -1,0 +1,33 @@
+FROM quay.io/openshift/origin-jenkins-agent-base:v4.0
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-agent-maven-35-rhel7-container" \
+      name="openshift4/jenkins-agent-maven-35-rhel7" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Agent Maven" \
+      io.k8s.description="The jenkins agent maven image has the maven tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,agent,maven" \
+      maintainer="openshift-dev-services+jenkins@redhat.com"
+
+ENV MAVEN_VERSION=3.5 \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    MAVEN_OPTS="-Duser.home=$HOME"
+# TODO: Remove MAVEN_OPTS env once cri-o pushes the $HOME variable in /etc/passwd
+
+# Install Maven
+RUN INSTALL_PKGS="java-11-openjdk-devel java-1.8.0-openjdk-devel maven*" && \
+    yum module enable -y maven:${MAVEN_VERSION} && \
+    yum install -y $INSTALL_PKGS && \
+    rpm -V  java-11-openjdk-devel java-1.8.0-openjdk-devel maven && \
+    yum clean all -y && \
+    mkdir -p $HOME/.m2
+
+ADD contrib/bin/configure-agent /usr/local/bin/configure-agent
+ADD ./contrib/settings.xml $HOME/.m2/
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/agent-nodejs-10/Dockerfile.rhel8
+++ b/agent-nodejs-10/Dockerfile.rhel8
@@ -1,0 +1,32 @@
+FROM quay.io/openshift/origin-jenkins-agent-base:v4.0
+
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-agent-nodejs-10-rhel7-container" \
+      name="openshift4/jenkins-agent-nodejs-10-rhel7" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Agent Nodejs" \
+      io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,agent,nodejs" \
+      maintainer="openshift-dev-services+jenkins@redhat.com"
+
+ENV NODEJS_VERSION=10 \
+    NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
+
+# Install NodeJS
+RUN INSTALL_PKGS="nodejs nodejs-nodemon make gcc-c++" && \
+    yum module enable -y nodejs:${NODEJS_VERSION} && \
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/agent-nodejs-12/Dockerfile.rhel8
+++ b/agent-nodejs-12/Dockerfile.rhel8
@@ -1,0 +1,32 @@
+FROM quay.io/openshift/origin-jenkins-agent-base:v4.0
+
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-agent-nodejs-12-rhel7-container" \
+      name="openshift4/jenkins-agent-nodejs-12-rhel7" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Agent Nodejs" \
+      io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins slave base image." \
+      io.openshift.tags="openshift,jenkins,agent,nodejs" \
+      maintainer="openshift-dev-services+jenkins@redhat.com"
+
+ENV NODEJS_VERSION=12 \
+    NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+COPY contrib/bin/configure-agent /usr/local/bin/configure-agent
+
+# Install NodeJS
+RUN INSTALL_PKGS="nodejs nodejs-nodemon make gcc-c++" && \
+    yum module enable -y nodejs:${NODEJS_VERSION} && \
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum clean all -y
+
+RUN chown -R 1001:0 $HOME && \
+    chmod -R g+rw $HOME
+
+USER 1001

--- a/slave-base/Dockerfile.rhel8
+++ b/slave-base/Dockerfile.rhel8
@@ -1,0 +1,70 @@
+##############################################
+# Stage 1 : Build go-init
+##############################################
+FROM openshift/origin-release:golang-1.12 AS go-init-builder
+WORKDIR  /go/src/github.com/openshift/jenkins
+COPY . .
+WORKDIR  /go/src/github.com/openshift/jenkins/go-init
+RUN go build . && cp go-init /usr/bin
+
+##############################################
+# Stage 2 : Build slave-base with go-init
+##############################################
+FROM quay.io/openshift/origin-cli
+MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
+COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
+
+# Labels consumed by Red Hat build service
+LABEL com.redhat.component="jenkins-slave-base-rhel7-container" \
+      name="openshift4/jenkins-slave-base-rhel7" \
+      architecture="x86_64" \
+      io.k8s.display-name="Jenkins Slave Base" \
+      io.k8s.description="The jenkins slave base image is intended to be built on top of, to add your own tools that your jenkins job needs. The slave base image includes all the jenkins logic to operate as a slave, so users just have to yum install any additional packages their specific jenkins job will need" \
+      io.openshift.tags="openshift,jenkins,slave" \
+      maintainer="openshift-dev-services+jenkins@redhat.com"      
+
+
+ENV HOME=/home/jenkins \
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8
+
+USER root
+# Install headless Java
+RUN INSTALL_PKGS="bc gettext git java-11-openjdk-headless java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
+    yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
+    rpm -V  $INSTALL_PKGS && \
+    yum clean all && \
+    mkdir -p /home/jenkins && \
+    chown -R 1001:0 /home/jenkins && \
+    chmod -R g+w /home/jenkins && \
+    chmod -R 775 /etc/alternatives && \
+    chmod -R 775 /var/lib/alternatives && \
+    chmod -R 775 /usr/lib/jvm && \
+    chmod 775 /usr/bin && \
+    chmod 775 /usr/share/man/man1 && \
+    mkdir -p /var/lib/origin && \
+    chmod 775 /var/lib/origin && \    
+    unlink /usr/bin/java && \
+    unlink /usr/bin/jjs && \
+    unlink /usr/bin/keytool && \
+    unlink /usr/bin/pack200 && \
+    unlink /usr/bin/rmid && \
+    unlink /usr/bin/rmiregistry && \
+    unlink /usr/bin/unpack200 && \
+    unlink /usr/share/man/man1/java.1.gz && \
+    unlink /usr/share/man/man1/jjs.1.gz && \
+    unlink /usr/share/man/man1/keytool.1.gz && \
+    unlink /usr/share/man/man1/pack200.1.gz && \
+    unlink /usr/share/man/man1/rmid.1.gz && \
+    unlink /usr/share/man/man1/rmiregistry.1.gz && \
+    unlink /usr/share/man/man1/unpack200.1.gz
+
+# Copy the entrypoint
+ADD contrib/bin/* /usr/local/bin/
+
+# Run the Jenkins JNLP client
+ENTRYPOINT ["/usr/bin/go-init", "-main", "/usr/local/bin/run-jnlp-client"]
+
+##############################################
+# End
+##############################################


### PR DESCRIPTION
Separate files are required, as the changes necessary for building with
RHEL 8 content are not compatible with RHEL 7.  agent-nodejs-8 is skipped,
as RHEL 8 never shipped it.