### PR TITLE
[release-4.3] Bug 1819530: update subversion plugin

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -68,7 +68,7 @@ junit:1.26.1
 workflow-support:2.18
 git:4.2.2
 mercurial:2.3
-subversion:2.10.3
+subversion:2.13.1
 github:1.29.2
 github-branch-source:2.3.6
 workflow-cps:2.80


### PR DESCRIPTION
Various CVE including CVE-2020-2135 CVE-2020-2136: Update subversion plugin to 2.13.1