### PR TITLE
Bug 1883836: Update nodejs-agent imagestream to v12

### DIFF
--- a/openshift/imagestreams/jenkins-agent-nodejs-rhel.json
+++ b/openshift/imagestreams/jenkins-agent-nodejs-rhel.json
@@ -37,7 +37,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/openshift4/ose-jenkins-agent-nodejs:v4.0"
+          "name": "registry.redhat.io/openshift4/ose-jenkins-agent-nodejs-12-rhel8:v4.6"
         },
         "referencePolicy": {
           "type": "Local"

--- a/openshift/imagestreams/jenkins-agent-nodejs-rhel.yaml
+++ b/openshift/imagestreams/jenkins-agent-nodejs-rhel.yaml
@@ -28,7 +28,7 @@ spec:
       tags: jenkins
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-jenkins-agent-nodejs:v4.0
+      name: registry.redhat.io/openshift4/ose-jenkins-agent-nodejs-12-rhel8:v4.6
     referencePolicy:
       type: Local
 


### PR DESCRIPTION
Reference location for image : https://catalog.redhat.com/software/containers/openshift4/jenkins-agent-nodejs-12-rhel7/5ea81a4ad70cc54b02d62294?container-tabs=gti
