### PR TITLE
Updating openshift-jenkins-2 builder & base images to be consistent with ART

### DIFF
--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -1,7 +1,7 @@
 ##############################################
 # Stage 1 : Build go-init
 ##############################################
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS go-init-builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS go-init-builder
 WORKDIR  /go/src/github.com/openshift/jenkins
 COPY . .
 WORKDIR  /go/src/github.com/openshift/jenkins/go-init
@@ -10,7 +10,7 @@ RUN go build . && cp go-init /usr/bin
 ##############################################
 # Stage 2 : Build slave-base with go-init
 ##############################################
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:cli
 MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 


### PR DESCRIPTION
Updating openshift-jenkins-2 builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/ac81dd4ff0bd57c4e75058d25b40615b92948259/images/openshift-jenkins-2.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/oc/pull/606 . Allow it to merge and then run `/test all` on this PR.