### PR TITLE
Updating ose-jenkins-agent-maven builder & base images to be consistent with ART

### DIFF
--- a/agent-maven-3.5/Dockerfile.rhel8
+++ b/agent-maven-3.5/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/4.6:jenkins-agent-base
+FROM registry.svc.ci.openshift.org/ocp/4.7:jenkins-agent-base
 MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
 
 # Labels consumed by Red Hat build service


### PR DESCRIPTION
Updating ose-jenkins-agent-maven builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/ose-jenkins-agent-maven.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/jenkins/pull/1165 . Allow it to merge and then run `/test all` on this PR.