### PR TITLE
[main] Bug 1904307: Update ant plugin CVE-2020-11979

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,5 @@
 
-ant:1.10
+ant:1.11
 blueocean:1.23.3
 bouncycastle-api:2.18
 config-file-provider:3.5


### PR DESCRIPTION
Fix already exists in https://github.com/apache/ant/commit/87ac51d3c22bcf7cfd0dc07cb0bd04a496e0d428
Using latest release of ant plugin as it is using the fixed version of ant