### PR TITLE
Update jenkins-rhel.yaml

### DIFF
--- a/openshift/imagestreams/jenkins-rhel.yaml
+++ b/openshift/imagestreams/jenkins-rhel.yaml
@@ -32,7 +32,7 @@ spec:
       version: 2.x
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-jenkins:v4.0
+      name: registry.redhat.io/openshift4/ose-jenkins:v4.4.0
     referencePolicy:
       type: Local
 


### PR DESCRIPTION
v4.0 tag is no longer available on the Red Hat Registry. It can be replaced with any tag, but since other tags may also be deleted, I just simply wanted to use the latest tag. However, the pod has never skipped the readiness checks. So that, I tried v4.4.0 and worked perfectly.

This is also related with https://github.com/openshift/cluster-samples-operator/pull/354

Below shows the Import Failure issue.
![Screen Shot 2021-02-08 at 10 54 51](https://user-images.githubusercontent.com/15480459/107191473-47f7da00-69fd-11eb-8e7e-d86b89a0b942.png)
