### PR TITLE
[WIP]add proxy system properties as expected by kubernetes-client

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -19,7 +19,7 @@ jira:3.0.17
 job-dsl:1.77
 junit:1.30
 kubernetes:1.29.0
-kubernetes-client-api:4.13.2-1
+kubernetes-client-api:4.13.3-1
 lockable-resources:2.10
 mailer:1.32.1
 mapdb-api:1.0.9.0

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -252,16 +252,17 @@ function get_java_proxy_config() {
   proto=$1
   json=$2
   config="-D$proto.proxyHost=$(echo $json | jq -r .host)  -D$proto.proxyPort=$(echo $json | jq -r .port) "
+  config="$config -D$proto.proxy=http://$(echo $json | jq -r .host | sed -e 's/[[:space:]]//g'):$(echo $json | jq -r .port)"
   username=$(echo $json | jq -r .username )
   if [ -n $username ]; then
-    config="$config -D$proto.proxyUser=$username"
+    config="$config -D$proto.proxyUser=$username -Dproxy.username=$username"
   fi
   password=$(echo $json | jq -r .password )
   if [ -n $password ]; then
-    config="$config -D$proto.proxyPassword=$password"
+    config="$config -D$proto.proxyPassword=$password -Dproxy.password=$password"
   fi
   if [ -n "$no_proxy" ]; then
-    config="$config -D$proto.nonProxyHosts=$(convert_no_proxy $no_proxy)"
+    config="$config -D$proto.nonProxyHosts=$(convert_no_proxy $no_proxy) -Dno.proxy=$no_proxy"
   fi
   echo $config
 }


### PR DESCRIPTION
system properties are expected in this format , keeping the old ones because it is the standard way for java application to receive the proxy settigns, so some other plugins may use the standard way

https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/Config.java#L119

Putting this in WIP because it needs https://github.com/fabric8io/kubernetes-client/pull/3000
I will then bump the plugin in the current PR
