### PR TITLE
Nuke custom credentials for kubernetes-plugin

### DIFF
--- a/2/contrib/jenkins/kube-slave-common.sh
+++ b/2/contrib/jenkins/kube-slave-common.sh
@@ -150,27 +150,8 @@ function generate_kubernetes_config() {
       <namespace>${PROJECT_NAME}</namespace>
       <jenkinsUrl>http://${JENKINS_SERVICE_HOST}:${JENKINS_SERVICE_PORT}</jenkinsUrl>
       <jenkinsTunnel>${JNLP_HOST}:${JNLP_PORT}</jenkinsTunnel>
-      <credentialsId>1a12dfa4-7fc5-47a7-aa17-cc56572a41c7</credentialsId>
       <containerCap>100</containerCap>
       <retentionTimeout>5</retentionTimeout>
     </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
-    "
-}
-
-# generate_kubernetes_credentials generates the credentials entry for the
-# kubernetes service account.
-function generate_kubernetes_credentials() {
-  echo "<entry>
-      <com.cloudbees.plugins.credentials.domains.Domain>
-        <specifications/>
-      </com.cloudbees.plugins.credentials.domains.Domain>
-      <java.util.concurrent.CopyOnWriteArrayList>
-        <org.csanchez.jenkins.plugins.kubernetes.ServiceAccountCredential plugin=\"kubernetes@0.4.1\">
-          <scope>GLOBAL</scope>
-          <id>1a12dfa4-7fc5-47a7-aa17-cc56572a41c7</id>
-          <description></description>
-        </org.csanchez.jenkins.plugins.kubernetes.ServiceAccountCredential>
-      </java.util.concurrent.CopyOnWriteArrayList>
-    </entry>
     "
 }

--- a/2/contrib/openshift/configuration/credentials.xml.tpl
+++ b/2/contrib/openshift/configuration/credentials.xml.tpl
@@ -1,6 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin="credentials@1.23">
-  <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
-    ${KUBERNETES_CREDENTIALS}
-  </domainCredentialsMap>
-</com.cloudbees.plugins.credentials.SystemCredentialsProvider>

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -96,20 +96,6 @@ function create_jenkins_proxy_xml() {
   fi
 }
 
-function create_jenkins_credentials_xml() {
-  if [ ! -f "${image_config_dir}/credentials.xml" ]; then
-    if [ -f "${image_config_dir}/credentials.xml.tpl" ]; then
-      if [ ! -z "${KUBERNETES_CONFIG}" ]; then
-        echo "Generating kubernetes-plugin credentials (${JENKINS_HOME}/credentials.xml.tpl) ..."
-        export KUBERNETES_CREDENTIALS=$(generate_kubernetes_credentials)
-      fi
-      # Fix the envsubst trying to substitute the $Hash inside credentials.xml
-      export Hash="\$Hash"
-      envsubst < "${image_config_dir}/credentials.xml.tpl" > "${image_config_dir}/credentials.xml"
-    fi
-  fi
-}
-
 function create_jenkins_config_from_templates() {
   find ${image_config_dir} -type f -name "*.tpl" -print0 | while IFS= read -r -d '' template_path; do
     local target_path=${template_path%.tpl}
@@ -117,9 +103,6 @@ function create_jenkins_config_from_templates() {
       case "${target_path}" in
         "${image_config_path}")
           create_jenkins_config_xml
-          ;;
-        "${image_config_dir}/credentials.xml")
-          create_jenkins_credentials_xml
           ;;
         "${image_config_dir}/proxy.yaml")
           create_jenkins_proxy_xml


### PR DESCRIPTION
This is no longer necessary in recent versions of the plugin and it
causes problems because if a user is using configuration-as-code to
define their own credentials, it will overwrite our changes and the
kubernetes plugin will get confused trying to use it.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1956652
See: https://access.redhat.com/solutions/6016001