### PR TITLE
Bug 1972451: Correctly declare Jenkins URL with trailing slash

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -16,7 +16,7 @@ create_jenkins_location_configuration_xml() {
   if [ $( oc get routes -o json | jq -c -r '.items[0].spec.tls')  == "null" ]; then
     JENKINS_SCHEME="http://"
   fi
-  JENKINS_URL="$JENKINS_SCHEME$(oc get routes -o json | jq -c -r '.items[0].spec | select (.to.name == env.JENKINS_SERVICE_NAME ) | .host ')"
+  JENKINS_URL="$JENKINS_SCHEME$(oc get routes -o json | jq -c -r '.items[0].spec | select (.to.name == env.JENKINS_SERVICE_NAME ) | .host ')/"
   echo "Using JENKINS_SERVICE_NAME=$JENKINS_SERVICE_NAME"
   echo "Generating jenkins.model.JenkinsLocationConfiguration.xml using (${JENKINS_HOME}/jenkins.model.JenkinsLocationConfiguration.xml.tpl) ..."
   export JENKINS_URL


### PR DESCRIPTION
This is normally enforced by Jenkins itself, though since this is injected through direct modification of the XML file, the incorrect version stays in. There are rare situations when plugins do not expect the values does not adhere to invariants imposed by Jenkins and fail when run in OpenShift:

https://github.com/jenkinsci/jenkins/blob/a1175b932e1ac97085d69752f5821141d012314f/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java#L144