### PR TITLE
Bug 1972354: Bump jenkins version 2.289.2

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -30,7 +30,7 @@ ENV JENKINS_VERSION=2 \
     HOME=/var/lib/jenkins \
     JENKINS_HOME=/var/lib/jenkins \
     JENKINS_UC=https://updates.jenkins.io \
-    OPENSHIFT_JENKINS_IMAGE_VERSION=4.6 \
+    OPENSHIFT_JENKINS_IMAGE_VERSION=4.8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     INSTALL_JENKINS_VIA_RPMS=false
@@ -39,7 +39,7 @@ LABEL k8s.io.description="Jenkins is a continuous integration server" \
       k8s.io.display-name="Jenkins 2" \
       openshift.io.expose-services="8080:http" \
       openshift.io.tags="jenkins,jenkins2,ci" \
-      io.jenkins.version="2.277.3" \
+      io.jenkins.version="2.289.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # 8080 for main web interface, 50000 for slave agents

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -30,7 +30,7 @@ ENV JENKINS_VERSION=2 \
     HOME=/var/lib/jenkins \
     JENKINS_HOME=/var/lib/jenkins \
     JENKINS_UC=https://updates.jenkins.io \
-    OPENSHIFT_JENKINS_IMAGE_VERSION=4.7 \
+    OPENSHIFT_JENKINS_IMAGE_VERSION=4.8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     INSTALL_JENKINS_VIA_RPMS=false
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.277.3" \
+      io.jenkins.version="2.289.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -30,7 +30,7 @@ ENV JENKINS_VERSION=2 \
     HOME=/var/lib/jenkins \
     JENKINS_HOME=/var/lib/jenkins \
     JENKINS_UC=https://updates.jenkins.io \
-    OPENSHIFT_JENKINS_IMAGE_VERSION=4.7 \
+    OPENSHIFT_JENKINS_IMAGE_VERSION=4.8 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     INSTALL_JENKINS_VIA_RPMS=false
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.277.3" \
+      io.jenkins.version="2.289.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -18,8 +18,8 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == "false" ]]; then
       rm -fr /var/cache/yum/x86_64/7Server/*
       rm -fr /var/cache/yum/x86_64/7Server/ # Clean yum cache otherwise, it will fail if --disablerepos are specified
     fi
-    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.277.3
-    rpm -V jenkins-2.277.3
+    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.289.2
+    rpm -V jenkins-2.289.2
     yum $YUM_FLAGS clean all
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else


### PR DESCRIPTION
This PR updates broken Jenkins image in 4.7 and 4.8 which introduced a faulty dependant plugin.
The updated plugin needs this version of Jenkins.
