### PR TITLE
Bug 1925524: have to bump k8s to 1.30 before we can bump sync to 1.0.48 in sync repo for its tests to pass

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -17,14 +17,12 @@ htmlpublisher:1.21
 jira:3.0.17
 job-dsl:1.77
 junit:1.30
-kubernetes:1.29.7
-kubernetes-client-api:4.13.3-1
+kubernetes:1.30.1
 lockable-resources:2.10
 mapdb-api:1.0.9.0
 matrix-auth:2.6.6
 matrix-project:1.18
 mercurial:2.12
-metrics:4.0.2.6
 openshift-client:1.0.35
 openshift-login:1.0.26
 openshift-sync:1.0.46


### PR DESCRIPTION
See https://github.com/openshift/jenkins-sync-plugin/pull/389#issuecomment-883337232 and https://github.com/openshift/jenkins-sync-plugin/pull/389#issuecomment-883342163

/hold

I want to check the build log to make sure the jackson 2 plugin is correct, assuming tests pass with the new k8s and v1.0.46 of sync plugin.

Then I will unhold.