### PR TITLE
Bug 1993195: testing performance of sync plugin

### DIFF
--- a/smoke/features/README.md
+++ b/smoke/features/README.md
@@ -1,7 +1,6 @@
 ## Testing the template based install of jenkins on openshift
 
 ### The smoke test written using behave framework for python has the below tree structure
-<pre><font color="#0000FF"><b>smoke</b></font>
 ├── <font color="#0000FF"><b>features</b></font>
 │   ├── environment.py
 │   ├── jenkins-ephemeral.feature
@@ -25,9 +24,7 @@
     └── nodejs_pipeline.yaml
 </pre>
 
-
-### Run the smoke test
-
+### Run the smoke test<pre><font color="#0000FF"><b>smoke</b></font>
 <pre>- oc login to/the/openshift/cluster -u username -p password --kubeconfig=kubeconfig
 - export KUBECONFIG=kubeconfig
 - make smoke</pre>

--- a/smoke/features/steps/openshift.py
+++ b/smoke/features/steps/openshift.py
@@ -261,6 +261,21 @@ class Openshift(object):
             elif 'jenkins-1-' in pod and deploy_pod not in pod:
                 master_pod = pod
         return master_pod
+    
+    def scaleReplicas(self, namespace: str, replicas: int, rep_controller: str):
+        '''
+        Scales up or down the pod count that ensures that a specified number of replicas of a pod are running at all times.\n
+        namespace -> project name\n
+        replicas -> desried count of the pod running all times.\n
+        rep_controller -> replication controller name\n
+        e.g: oc scale --replicas=2 rc/jenkins-1
+        '''
+        cmd = f'oc scale --replicas={replicas} rc/{rep_controller} -n {namespace}'
+        output, exit_status = self.cmd.run(cmd)
+        print(f"{output}")
+        if exit_status == 0:
+            return output
+        return None
 
 
 

--- a/smoke/features/steps/project.py
+++ b/smoke/features/steps/project.py
@@ -4,7 +4,7 @@ from smoke.features.steps.command import Command
 
 
 class Project():
-    def __init__(self, name='jenkins-test'):
+    def __init__(self, name=''):
         self.name = name
         self.cmd = Command()
 

--- a/smoke/features/steps/steps.py
+++ b/smoke/features/steps/steps.py
@@ -41,7 +41,7 @@ plugins = p.getPlugins(baseplugins)
 
 
 def triggerbuild(buildconfig,namespace):
-    print('Triggering build:',buildconfig)
+    print('Triggering build: ',buildconfig)
     res = oc.start_build(buildconfig,namespace)
     print(res)
 
@@ -501,7 +501,7 @@ def multiplebuilds(context):
         builds[build_name] = None
         count+=1
     
-@when(u'We slace down the pod count in the replication controller to "0" from "1"')
+@when(u'We scale down the pod count in the replication controller to "0" from "1"')
 def podscaling(context):
     rc_name = 'jenkins-1'
     oc.scaleReplicas(current_project,0,rc_name)

--- a/smoke/features/stress-test.feature
+++ b/smoke/features/stress-test.feature
@@ -6,7 +6,7 @@ Feature: To test sync plugin performance and stability on different load
     Scenario: Test openshift-sync plugin performance and stability
       Given The jenkins pod is up and runnning
       When We Trigger multiple builds using oc start-build openshift-jee-sample
-      And We slace down the pod count in the replication controller to "0" from "1"
+      And We scale down the pod count in the replication controller to "0" from "1"
       Then We delete some builds
       Then We check for jenkins master pod status to be "Ready"
       And verify sync plugin is able to reconcile the build state and delete the job runs associated with the builds we deleted

--- a/smoke/features/stress-test.feature
+++ b/smoke/features/stress-test.feature
@@ -1,0 +1,12 @@
+Feature: To test sync plugin performance and stability on different load
+
+    Background:
+    Given Project [TEST_NAMESPACE] is used
+
+    Scenario: Test openshift-sync plugin performance and stability
+      Given The jenkins pod is up and runnning
+      When We Trigger multiple builds using oc start-build openshift-jee-sample
+      And We slace down the pod count in the replication controller to "0" from "1"
+      Then We delete some builds
+      Then We check for jenkins master pod status to be "Ready"
+      And verify sync plugin is able to reconcile the build state and delete the job runs associated with the builds we deleted


### PR DESCRIPTION
**Testing the performance of sync plugin**
```
- create 5 builds
- bring down jenkins
- delete a few of the builds via oc
- bring jenkins back up
- see that sync plugin is able to reconcile state and delete the job runs associated with the builds we deleted
```
- Update the README.MD for smoke test