### PR TITLE
Add support for websocket connection to Jenkins

### DIFF
--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -101,6 +101,12 @@ if [[ $# -eq 0 ]]; then
   if [ ! -z "$JENKINS_NAME" ]; then
     set -- "${@}" "$JENKINS_NAME"
   fi
+  
+  # If Kubernetes plugin is configured to use WebSocket, add the -webSocket flag to the arguments
+  if [ ! -z "$JENKINS_WEB_SOCKET" ]; then
+    set -- "${@}" "-webSocket"
+  fi
+
 fi
 
 # if `docker run` has 2 or more arguments the user is passing jenkins launcher arguments

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -103,8 +103,10 @@ if [[ $# -eq 0 ]]; then
   fi
   
   # If Kubernetes plugin is configured to use WebSocket, add the -webSocket flag to the arguments
-  if [ ! -z "$JENKINS_WEB_SOCKET" ]; then
-    set -- "${@}" "-webSocket"
+  if [[ "$@" != *"-webSocket"* ]]; then
+    if [ ! -z "$JENKINS_WEB_SOCKET" ]; then
+      set -- "${@}" "-webSocket"
+    fi
   fi
 
 fi


### PR DESCRIPTION
When you configure Kubernetes cloud configuration in Jenkins to use Websocket connection, the Kubernetes plugin adds the JENKINS_WEB_SOCKET env variable, but that variable is ignored by the agent base image and it does not add the webSocket flag. 