### PR TITLE
Bug 2015085: update git plugin to version 4.8.3

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -9,7 +9,7 @@ credentials:2.5
 cloudbees-folder:6.16
 docker-commons:1.17
 git-client:3.9.0
-git:4.8.2
+git:4.8.3
 github:1.34.0
 google-oauth-plugin:1.0.6
 groovy:2.4


### PR DESCRIPTION
In order to fix the `CVE-2021-21684`, git plugin version has to be updated to version `4.8.3` according to [Jenkins Security Advisory 2021-10-06](https://www.jenkins.io/security/advisory/2021-10-06/)