### PR TITLE
Bug 2003204: Fix jbcrypt_path lookup

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -10,7 +10,7 @@ RUN go build . && cp go-init /usr/bin
 ##############################################
 # Stage 2 : Build slave-base with go-init
 ##############################################
-FROM quay.io/openshift/origin-cli:4.2
+FROM quay.io/openshift/origin-cli:4.10
 MAINTAINER Akram Ben Aissi <abenaiss@redhat.com>
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 

--- a/2/contrib/jenkins/jenkins-common.sh
+++ b/2/contrib/jenkins/jenkins-common.sh
@@ -15,7 +15,7 @@ function obfuscate_password {
     local salt="$2"
     #local acegi_security_path=`find /tmp/war/WEB-INF/lib/ -name acegi-security-*.jar`
     #local commons_codec_path=`find /tmp/war/WEB-INF/lib/ -name commons-codec-*.jar`
-    local jbcrypt_path=`find /tmp/war/WEB-INF/lib/ -name jbcrypt-*.jar`
+    local jbcrypt_path=`find /tmp/war/WEB-INF/lib ${JENKINS_HOME}/war/WEB-INF/lib/ -name jbcrypt-*.jar 2> /dev/null | head -1`
     # source for password-encoder.jar is inside the jar.
     # acegi-security-1.0.7.jar is inside the jenkins war.
 #    java -classpath "${acegi_security_path}:${commons_codec_path}:/opt/openshift/password-encoder.jar" com.redhat.openshift.PasswordEncoder $password $salt
@@ -26,7 +26,7 @@ function obfuscate_password {
 function has_password_changed {
     local password="$1"
     local password_hash="$2"
-    local jbcrypt_path=`find /tmp/war/WEB-INF/lib/ -name jbcrypt-*.jar`
+    local jbcrypt_path=`find /tmp/war/WEB-INF/lib ${JENKINS_HOME}/war/WEB-INF/lib/ -name jbcrypt-*.jar 2> /dev/null | head -1`
     # source for password-encoder.jar is inside the jar.
      java -classpath "${jbcrypt_path}:/opt/openshift/password-encoder.jar" com.redhat.openshift.PasswordChecker $password $password_hash
 }

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -17,11 +17,12 @@ shopt -s dotglob
 
 function update_admin_password() {
   # get random admin dir
-  ADMIN_DIR=`ls /var/lib/jenkins/users | grep admin`
-  ls ${JENKINS_HOME}/users/${ADMIN_DIR}
+  ADMIN_DIR=`ls /var/lib/jenkins/users | grep ^admin_` # Use strictly user admin (not kubeadmin or another)
   new_password_hash=$(obfuscate_password ${JENKINS_PASSWORD:-password})
+  echo "Updating password hash in $ADMIN_DIR for user admin"
   sed -i "s,<passwordHash>.*</passwordHash>,<passwordHash>#jbcrypt:$new_password_hash</passwordHash>,g" "${JENKINS_HOME}/users/${ADMIN_DIR}/config.xml"
   echo $new_password_hash > ${JENKINS_HOME}/password
+  echo "Password hash susccesfully updated"
 }
 
 function create_jenkins_config_xml() {
@@ -533,8 +534,9 @@ if [ -e ${JENKINS_HOME}/password ]; then
   # we don't want to just blindly do this on startup because the user might change their password via
   # the jenkins ui, so we only want to do this if the env variable has been explicitly modified from
   # the original value.
-  old_password_hash=`cat ${JENKINS_HOME}/password`
-  password_changed=$(has_password_changed ${JENKINS_PASSWORD:-password} ${old_password_hash} )
+  old_password_hash=$(head -1 ${JENKINS_HOME}/password )
+  default_password_hash='$2a$10$Ueyz5nnKl/AnQuD75rulE.Z7nVHnzsfgWCwOajccw3xnDt9OBkSc2'
+  password_changed=$(has_password_changed ${JENKINS_PASSWORD:-password} ${old_password_hash:-${default_password_hash}} )
   if [ "$password_changed" != "" ]; then
     echo "Detected password environment variable change, updating Jenkins configuration ..."
     update_admin_password


### PR DESCRIPTION
In resulting image, jbcrypt is not extracted into /tmp/war but rather it is present under directories in /var/lib/jenkins/war/ 