### PR TITLE
[release-3.11] Bug 2020611: Update Jenkins and plugins per 2021-11 advisory

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -38,7 +38,7 @@ RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/j
     #run yum update to avoid package version mismatch between i686 and other archs
     yum -y update && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-11-openjdk.i686 java-11-openjdk-devel.i686 ; fi) && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.289.1 nss_wrapper" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.289.2 nss_wrapper" && \
     yum -y --setopt=protected_multilib=false --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
     rpm -V  $INSTALL_PKGS $x86_EXTRA_RPMS && \
     yum clean all  && \

--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -38,7 +38,7 @@ RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/j
     #run yum update to avoid package version mismatch between i686 and other archs
     yum -y update && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-11-openjdk.i686 java-11-openjdk-devel.i686 ; fi) && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.289.2 nss_wrapper" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.303.3 nss_wrapper" && \
     yum -y --setopt=protected_multilib=false --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
     rpm -V  $INSTALL_PKGS $x86_EXTRA_RPMS && \
     yum clean all  && \

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -43,7 +43,7 @@ prometheus:2.0.0
 script-security:1.77
 snakeyaml-api:1.27.0
 ssh-credentials:1.18.1
-subversion:2.13.2
+subversion:2.15.1
 token-macro:2.13
 workflow-aggregator:2.6
 workflow-cps-global-lib:2.15

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,3 +1,4 @@
+
 ant:1.11
 blueocean:1.24.4
 bouncycastle-api:2.18
@@ -20,6 +21,7 @@ junit:1.30
 kubernetes:1.29.7
 kubernetes-client-api:4.13.3-1
 lockable-resources:2.10
+mailer:1.32.1
 mapdb-api:1.0.9.0
 matrix-auth:2.6.6
 matrix-project:1.18
@@ -30,9 +32,22 @@ openshift-login:1.0.26
 openshift-pipeline:1.0.57
 openshift-sync:1.0.46
 pam-auth:1.6
+parameterized-trigger:2.36
+pipeline-build-step:2.12
+pipeline-github-lib:1.0
+pipeline-input-step:2.11
+pipeline-model-api:1.7.2
+pipeline-model-definition:1.6.0
+pipeline-utility-steps:2.5.0
 prometheus:2.0.0
-snakeyaml-api:1.27.0
 script-security:1.77
+snakeyaml-api:1.27.0
 ssh-credentials:1.18.1
 subversion:2.13.2
 token-macro:2.13
+workflow-aggregator:2.6
+workflow-cps-global-lib:2.15
+workflow-cps:2.87
+workflow-multibranch:2.22
+workflow-remote-loader:1.5
+workflow-support:3.6


### PR DESCRIPTION
Bump Jenkins to 2.303.3 to address the following CVEs:

- CVE-2021-21685
- CVE-2021-21686
- CVE-2021-21687
- CVE-2021-21688
- CVE-2021-21689
- CVE-2021-21690
- CVE-2021-21691
- CVE-2021-21692
- CVE-2021-21693
- CVE-2021-21694
- CVE-2021-21695
- CVE-2021-21696
- CVE-2021-21697

Also update the subversion plugin to address CVE-2021-21698.