### PR TITLE
Bug 2020610: Update subversion plugin to 2.15.1

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -32,5 +32,5 @@ prometheus:2.0.10
 snakeyaml-api:1.29.1
 script-security:1.78
 ssh-credentials:1.19
-subversion:2.14.4
+subversion:2.15.1
 token-macro:266.v44a80cf277fd


### PR DESCRIPTION
Subversion plugin version is updated to 2.15.1 in order to fix security issues (see more at https://www.jenkins.io/security/advisory/2021-11-04/#fix).