### PR TITLE
[release-4.6] Bug 2020612: Update Jenkins and plugins per 2021-11 advisory

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -39,7 +39,7 @@ LABEL k8s.io.description="Jenkins is a continuous integration server" \
       k8s.io.display-name="Jenkins 2" \
       openshift.io.expose-services="8080:http" \
       openshift.io.tags="jenkins,jenkins2,ci" \
-      io.jenkins.version="2.289.2" \
+      io.jenkins.version="2.303.3" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # 8080 for main web interface, 50000 for slave agents

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.289.2" \
+      io.jenkins.version="2.303.3" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.289.2" \
+      io.jenkins.version="2.303.3" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -18,8 +18,12 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == "false" ]]; then
       rm -fr /var/cache/yum/x86_64/7Server/*
       rm -fr /var/cache/yum/x86_64/7Server/ # Clean yum cache otherwise, it will fail if --disablerepos are specified
     fi
-    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.289.2
-    rpm -V jenkins-2.289.2
+    # Since the recent LTS jenkins update we need to install the 'daemonize' package
+    # which is only available in EPEL, so enable it here
+    yum -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install \
+	    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.303.3
+    rpm -V jenkins-2.303.3
     yum $YUM_FLAGS clean all
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -42,7 +42,7 @@ prometheus:2.0.0
 script-security:1.75
 snakeyaml-api:1.27.0
 ssh-credentials:1.18.1
-subversion:2.13.2
+subversion:2.15.1
 token-macro:2.13
 workflow-aggregator:2.6
 workflow-cps-global-lib:2.15


### PR DESCRIPTION
- Update Jenkins core to 2.303.3 to address critical CVE adivsories
- Update Subversion plugin to 2.15.1 to address CVE-2021-21698