### PR TITLE
Change smoke tests so they can run in openshift-ci

### DIFF
--- a/scripts/test-jenkins-template-install.sh
+++ b/scripts/test-jenkins-template-install.sh
@@ -17,12 +17,23 @@ ${PYTHON_VENV_DIR}/bin/pip install --upgrade setuptools
 ${PYTHON_VENV_DIR}/bin/pip install --upgrade pip
 # -- Generating a new namespace name
 echo "test-namespace-$(uuidgen | tr '[:upper:]' '[:lower:]' | head -c 8)" > ${OUTPUT_DIR}/test-namespace
+if [[ $OPENSHIFT_CI == true ]]; then
+    # openshift-ci will not allow to create different namespaces, so will do all in the same namespace.
+    oc project -q > ${OUTPUT_DIR}/test-namespace
+fi
 export TEST_NAMESPACE=$(cat ${OUTPUT_DIR}/test-namespace)
-echo "Assigning value to variable TEST_NAMESPACE:"${TEST_NAMESPACE}
+echo "Assigning value to variable TEST_NAMESPACE=${TEST_NAMESPACE}"
 # -- Do clean up & create namespace
 echo "Starting cleanup"
-kubectl delete namespace ${TEST_NAMESPACE} --timeout=45s --wait
-kubectl create namespace ${TEST_NAMESPACE}
+if [[ $OPENSHIFT_CI == true ]]; then
+    oc delete all,rolebindings.authorization.openshift.io,bc,cm,is,pvc,sa,secret -l app=jenkins-ephemeral
+    oc delete all,rolebindings.authorization.openshift.io,bc,cm,is,pvc,sa,secret -l app=jenkins-persistent
+    oc delete all,rolebindings.authorization.openshift.io,bc,cm,is,pvc,sa,secret -l app=openshift-jee-sample
+    oc delete all,rolebindings.authorization.openshift.io,bc,cm,is,pvc,sa,secret -l app=jenkins-pipeline-example
+else
+    kubectl delete namespace ${TEST_NAMESPACE} --timeout=45s --wait
+    kubectl create namespace ${TEST_NAMESPACE}
+fi
 mkdir -p ${LOGS_DIR}/smoke-tests-logs
 mkdir -p ${OUTPUT_DIR}/smoke-tests-output
 touch ${OUTPUT_DIR}/backups.txt
@@ -35,7 +46,9 @@ oc project ${TEST_NAMESPACE}
 # -- Trigger the test
 echo "Starting local Jenkins instance"
 ${PYTHON_VENV_DIR}/bin/pip install -q -r smoke/requirements.txt
-echo "Running smoke tests"
-TEST_NAMESPACE=${TEST_NAMESPACE}
-${PYTHON_VENV_DIR}/bin/behave --junit --junit-directory ${TEST_SMOKE_OUTPUT_DIR} --no-capture --no-capture-stderr smoke/features
-echo "Logs collected at "${TEST_SMOKE_OUTPUT_DIR}
+echo "Running smoke tests in namespace with TEST_NAMESPACE=${TEST_NAMESPACE}"
+echo "Logs will be collected in "${TEST_SMOKE_OUTPUT_DIR}
+${PYTHON_VENV_DIR}/bin/behave --junit --junit-directory ${TEST_SMOKE_OUTPUT_DIR} \
+                              --no-capture --no-capture-stderr \
+                              smoke/features -D project_name=${TEST_NAMESPACE}                           
+echo "Logs collected in "${TEST_SMOKE_OUTPUT_DIR}

--- a/smoke/features/jenkins-maven-agent.feature
+++ b/smoke/features/jenkins-maven-agent.feature
@@ -16,6 +16,6 @@ Feature: Testing jenkins agent maven image
       And verify service/openshift-jee-sample is created
       And verify route.route.openshift.io/openshift-jee-sample is created
       Then Trigger the build using oc start-build openshift-jee-sample
-      Then verify the build status of openshift-jee-sample-docker build is Complete
-      And verify the build status of openshift-jee-sample-1 is Complete
+      Then verify the build status of openshift-jee-sample-1 is Complete
+      And verify the build status of openshift-jee-sample-docker build is Complete
       And verify the JaveEE application is accessible via route openshift-jee-sample

--- a/smoke/features/jenkins-nodejs-agent.feature
+++ b/smoke/features/jenkins-nodejs-agent.feature
@@ -13,4 +13,5 @@ Feature: Testing jenkins agent nodejs image
     Then Trigger the build using oc start-build
     Then verify the build status of "nodejs-postgresql-example-1" build is Complete
     Then verify the build status of "nodejs-postgresql-example-2" build is Complete
+    Then We check for deployment pod status to be "Completed"
     And route nodejs-postgresql-example must be created and be accessible

--- a/smoke/features/jenkins-teardown-ephemeral.feature
+++ b/smoke/features/jenkins-teardown-ephemeral.feature
@@ -19,3 +19,4 @@ Feature: Delete all resources created using jenkins ephemeral template
         And  delete all builds
         And delete all build pods
         And delete all deploymentconfig
+        And delete all remaining test resources

--- a/smoke/features/persistent-maven-agent.feature
+++ b/smoke/features/persistent-maven-agent.feature
@@ -16,6 +16,6 @@ Feature: Testing jenkins agent maven image
       And verify service/openshift-jee-sample is created
       And verify route.route.openshift.io/openshift-jee-sample is created
       Then Trigger the build using oc start-build openshift-jee-sample
-      Then verify the build status of openshift-jee-sample-docker build is Complete
-      And verify the build status of openshift-jee-sample-1 is Complete
+      Then verify the build status of openshift-jee-sample-1 is Complete
+      And verify the build status of openshift-jee-sample-docker build is Complete
       And verify the JaveEE application is accessible via route openshift-jee-sample


### PR DESCRIPTION
Changing the smoke test so they can be run in openshift-ci i.e in an environment where creating new namespaces is not allowed
* Adding detection of OPENSHIFT_CI env var and in this case run the smoke tests in the current namespace
* Adds resources cleanup on startup to allow re-run of smoke tests in the local project
* Adds a step that cleans the test resources between launches, the existing one was not cleaning postgres resources and it was failing.
* Adds while loop waiting in many @then steps to avoir unecessary wait time
* Re order some events waiting that were breaking the tests

/assign @jitendar-singh  
can you PTAL @jitendar-singh and @adambkaplan ?
The next coming PR would contain the additional smoke test verifying JENKINS_PASSWORD env var usage. 