### PR TITLE
Bug 2037346: Update openshift-sync-plugin to 1.0.51 and various dependant plugins

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,15 +1,12 @@
 ant:1.11
 blueocean:1.24.8
-bouncycastle-api:2.23
 config-file-provider:3.8.1
 configuration-as-code:1.52
 configuration-as-code-groovy:1.1
 credentials-binding:1.27
-credentials:2.5
 cloudbees-folder:6.16
 docker-commons:1.17
 git-client:3.9.0
-git:4.8.2
 github:1.34.0
 google-oauth-plugin:1.0.6
 groovy:2.4
@@ -17,7 +14,6 @@ htmlpublisher:1.25
 jira:3.5
 job-dsl:1.77
 junit:1.52
-kubernetes:1.30.1
 lockable-resources:2.11
 mapdb-api:1.0.9.0
 matrix-auth:2.6.8
@@ -26,7 +22,7 @@ mercurial:2.15
 metrics:4.0.2.8
 openshift-client:1.0.35
 openshift-login:1.0.26
-openshift-sync:1.0.50
+openshift-sync:1.0.51
 pam-auth:1.6
 prometheus:2.0.10
 snakeyaml-api:1.29.1


### PR DESCRIPTION
Update the openshift-sync-plugin to fix bugs related to syncing BuildConfigs and other OpenShift resources.

Backport of #1358.
