### PR TITLE
Bug 2044938: Jenkins Fixes for CVE-2022-20617 and CVE-2022-20612

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -39,7 +39,7 @@ LABEL k8s.io.description="Jenkins is a continuous integration server" \
       k8s.io.display-name="Jenkins 2" \
       openshift.io.expose-services="8080:http" \
       openshift.io.tags="jenkins,jenkins2,ci" \
-      io.jenkins.version="2.303.3" \
+      io.jenkins.version="2.319.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i
 
 # 8080 for main web interface, 50000 for slave agents

--- a/2/Dockerfile.rhel7
+++ b/2/Dockerfile.rhel7
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.303.3" \
+      io.jenkins.version="2.319.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -43,7 +43,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
       io.k8s.display-name="Jenkins 2" \
       io.openshift.tags="jenkins,jenkins2,ci" \
       io.openshift.expose-services="8080:http" \
-      io.jenkins.version="2.303.3" \
+      io.jenkins.version="2.319.2" \
       io.openshift.s2i.scripts-url=image:///usr/libexec/s2i 
 
 # Labels consumed by Red Hat build service

--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -22,8 +22,8 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == "false" ]]; then
     # which is only available in EPEL, so enable it here
     yum -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install \
 	    https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.303.3
-    rpm -V jenkins-2.303.3
+    yum -y $YUM_FLAGS --setopt=tsflags=nodocs --disableplugin=subscription-manager install jenkins-2.319.2
+    rpm -V jenkins-2.319.2
     yum $YUM_FLAGS clean all
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -8,7 +8,7 @@ configuration-as-code-groovy:1.1
 credentials-binding:1.23
 credentials:2.3.15
 cloudbees-folder:6.15
-docker-commons:1.16
+docker-commons:1.18
 git-client:3.2.1
 git:4.5.2
 github:1.33.0


### PR DESCRIPTION
Upgrade core Jenkins and plugins to address some of the vulnerabilities in the 2022-01 Jenkins security advisory:

- CVE-2022-20617: Update docker-commons to 1.18 to mitigate a vulnerability with unsanitized image names/tags.
- CVE-2022-20612: Upgrade core Jenkins to the current LTS release (2.319.2). This includes a fix for a CSRF vulnerability impacting 2.319.1 and lower.

Related Bugzilla bugs:

- https://bugzilla.redhat.com/show_bug.cgi?id=2044938