### PR TITLE
Bug 2044943: Jenkins Fixes for CVE-2022-20617 and CVE-2022-20612

### DIFF
--- a/2/Dockerfile
+++ b/2/Dockerfile
@@ -38,7 +38,7 @@ RUN curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/j
     #run yum update to avoid package version mismatch between i686 and other archs
     yum -y update && \
     x86_EXTRA_RPMS=$(if [ "$(uname -m)" == "x86_64" ]; then echo -n java-11-openjdk.i686 java-11-openjdk-devel.i686 ; fi) && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.303.3 nss_wrapper" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git tar zip unzip openssl bzip2 dumb-init java-11-openjdk java-11-openjdk-devel jenkins-2.319.2 nss_wrapper" && \
     yum -y --setopt=protected_multilib=false --setopt=tsflags=nodocs install $INSTALL_PKGS $x86_EXTRA_RPMS && \
     rpm -V  $INSTALL_PKGS $x86_EXTRA_RPMS && \
     yum clean all  && \

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -7,7 +7,7 @@ configuration-as-code-groovy:1.1
 credentials-binding:1.23
 credentials:2.3.19
 cloudbees-folder:6.15
-docker-commons:1.16
+docker-commons:1.18
 git-client:3.2.1
 git:4.7.2
 github:1.33.1


### PR DESCRIPTION
Upgrade core Jenkins and plugins to address some of the vulnerabilities in the 2022-01 Jenkins security advisory:

- CVE-2022-20617: Update docker-commons to 1.18 to mitigate a vulnerability with unsanitized image names/tags.
- CVE-2022-20612: Upgrade core Jenkins to the current LTS release (2.319.2). This includes a fix for a CSRF vulnerability impacting 2.319.1 and lower.

Related Bugzilla bugs:

- https://bugzilla.redhat.com/show_bug.cgi?id=2044943