### PR TITLE
JNKS-269: Adds git pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+BASE_PLUGINS_FILE=2/contrib/openshift/base-plugins.txt
+BUNDLE_PLUGINS_FILE=2/contrib/openshift/bundle-plugins.txt
+
+if [[ $BASE_PLUGINS_FILE -nt $BUNDLE_PLUGINS_FILE ]]
+then
+  echo "ERROR: $BUNDLE_PLUGINS_FILE file must be regenerated using 'make plugins-list'"
+  echo "ERROR: commit aborted: see $0"
+  echo "ERROR: to force commit by ingoring pre-commit hook run: 'git commit --no-verify' "
+  exit 1
+fi
+
+# if the $BASE_PLUGINS_FILE is only commit but user forgot to add the $BUNDLE_PLUGINS_FILE, then, we fail
+if ( git diff --cached --name-only | grep $BASE_PLUGINS_FILE )  ; then
+  if ( git diff --cached --name-only | grep -v $BUNDLE_PLUGINS_FILE |  grep -v $BASE_PLUGINS_FILE )  ; then 
+    echo "ERROR: $BASE_PLUGINS_FILE is being commited without $BUNDLE_PLUGINS_FILE"
+    echo "ERROR: You need to add $BUNDLE_PLUGINS_FILE to the current commit."
+    exit 2
+  fi
+fi
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,7 @@ Here are a few of those links for reference:
 Our plugins are constructed such that if they are running in an OpenShift pod, they can determine how to connect to the 
 associated OpenShift master automatically, and no configuration of the plugin from the Jenkins console is needed.
 
-If you choose to run an external Jenkins server and you would like to test interaction with an OpenShift master, you will need to manually configure the plugin.  See each plugin's README or the OpenShift documentation
-for the specifics.
+If you choose to run an external Jenkins server and you would like to test interaction with an OpenShift master, you will need to manually configure the plugin.  See each plugin's README or the OpenShift documentation for the specifics.
 
 An example flow when running in an OpenShift pod:
 
@@ -49,6 +48,10 @@ An example flow when running in an OpenShift pod:
     ```
     git clone https://github.com/openshift/<plugin in question>-plugin.git
     ```
+1. Enable the provided git hooks: see https://github.com/openshift/jenkins/blob/master/README.md#plugin-installation-for-centos7-v4.10+
+   ```
+   git config core.hooksPath .githooks/
+   ```
 1. In the root of the local repository, run maven 
     ```
     cd <plugin in question>-plugin
@@ -62,6 +65,8 @@ An example flow when running in an OpenShift pod:
 1. Find the <plugin name>.hpi built in the previous steps.
 1. Submit the file.
 1. Check that Jenkins should be restarted.
+
+
 
 ### Additional options for updating the plugin in Jenkins (when running in OpenShift)
 

--- a/README.md
+++ b/README.md
@@ -260,14 +260,28 @@ For v3, the file is processed by the following call in the [CentOS7 Dockerfile](
 /usr/local/bin/install-plugins.sh /opt/openshift/base-plugins.txt
 ```
 
-In v4. that call has been moved to [this script](2/contrib/jenkins/install-jenkins-core-plugins.sh), which is called from
-both `Dockerfile.localdev` and `Dockerfile.rhel7`.
+#### Plugin installation for CentOS7 V4
+In v4, that call has been moved to [this script](2/contrib/jenkins/install-jenkins-core-plugins.sh), which is called from
+both `Dockerfile.localdev`, `Dockerfile.rhel7` and `Dockerfile.rhel8`.
 
 Where both [base-plugins.txt](2/contrib/openshift/base-plugins.txt) and [install-plugins.sh](2/contrib/jenkins/install-plugins.sh)
 are copied into the image prior to that invocation.
 
 The running of `install-plugins.sh` will download the files listed in `base-plugins.txt`, and then open each plugin's manifest
 and download any needed dependencies listed, including upgrading any previously installed dependencies as needed.
+
+#### Plugin installation for CentOS7 V4.10+
+Starting from `release-4.10`, the `base-plugins.txt` file is instead used to generate `bundle-plugins.txt` which is the comprehensive
+list of plugins used by the Jenkins image. To generate this list, developers must run `make plugins-list` prior to commit `base-plugins.txt`. 
+A git hook is provided to enforce that `bundle-plugins.txt` is always newer than `base-plugins.txt` on every commit attempt. And `openshift-ci`
+also runs the `make plugins-list` to be sure that the locally generated list of plugins does not change between the developer commit and the 
+ci run.
+The `bundle-plugins.txt` becomes then the source of truth for the ran, tested and verified plugins list. This file is intended to be used by 
+anyone who wants to build a Jenkins Image with the exact same set of plugins. Hence, this file is used by the Red Hat internal release 
+team (ART) and does not alter the existing release process, except that instead of getting the list of plugins from a succesful build, we now get it 
+from a predefined, pre-test and historized file written to the code repository.
+
+
 
 To update the version of a plugin or add a new plugin, construct a PR for this repository that updates `base-plugins.txt` appropriately.
 Administrators for this repository will make sure necessary tests are run and merge the PR when things are ready.


### PR DESCRIPTION
Add git pre commit hook that if enabled ensures that developers re-generate `bundle-plugins.txt` and commit it on `base-plugins.txt` change.

/assign @gabemontero 
/assign @adambkaplan 
