### PR TITLE
Bug 2054822: allow Pipeline Utility Steps (2.12.0) to start

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -28,7 +28,7 @@ pam-auth:1.6
 pipeline-utility-steps:2.12.0
 prometheus:2.0.10
 scm-api:2.6.5
-script-security:1.78
+script-security:1131.v8b_b_5eda_c328e
 snakeyaml-api:1.29.1
 ssh-credentials:1.19
 subversion:2.15.1

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -93,7 +93,7 @@ popper-api:1.16.1-2
 prometheus:2.0.10
 pubsub-light:1.13
 scm-api:2.6.5
-script-security:1.78
+script-security:1131.v8b_b_5eda_c328e
 snakeyaml-api:1.29.1
 sse-gateway:1.24
 ssh-credentials:1.19


### PR DESCRIPTION
```
java.io.IOException: Failed to load: Pipeline Utility Steps (2.12.0)
 - Update required: Script Security Plugin (1.78) to be updated to 1131.v8b_b_5eda_c328e or higher
	at hudson.PluginWrapper.resolvePluginDependencies(PluginWrapper.java:1016)
	at hudson.PluginManager$2$1$1.run(PluginManager.java:535)
	at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:169)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:296)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1151)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:214)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:117)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

note those 2 tag levels of script security plugin seem to be at the same commit level, but plugin manager does not care.