### PR TITLE
Bug 2058751: [release-4.9] 2022-02-15 Security Advisory

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -24,9 +24,16 @@ openshift-client:1.0.35
 openshift-login:1.0.26
 openshift-sync:1.0.53
 pam-auth:1.6
+pipeline-build-step:2.16
+pipeline-utility-steps:2.12.0
 prometheus:2.0.10
 snakeyaml-api:1.29.1
 script-security:1.78
 ssh-credentials:1.19
 subversion:2.15.1
-token-macro:266.v44a80cf277fd
+token-macro:267.vcdaea6462991
+workflow-api:2.47
+workflow-cps:2660.vb_c0412dc4e6d
+workflow-cps-global-lib:564.ve62a_4eb_b_e039
+workflow-multibranch:711.vdfef37cda_816
+workflow-step-api:622.vb_8e7c15b_c95a_


### PR DESCRIPTION
- CVE-2022-25173 CVE-2022-25176 CVE-2022-25180: pin workflow-cps to 2660.vb_c0412dc4e6d
- CVE-2022-25174 CVE-2022-25177 CVE-2022-25178 CVE-2022-25181 CVE-2022-25182 CVE-2022-25183 : pin workflow-cps-global-lib to 564.ve62a_4eb_b_e039
- CVE-2022-25175 CVE-2022-25179: pin workflow-multibranch to 711.vdfef37cda_816
- CVE-2022-25184: pin pipleine-build-step to 2.