### PR TITLE
Bug 2066019: set necessary JVM args to allow jenkins JVM to come up on a FIPS node

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -640,7 +640,11 @@ if [ -n "$https_proxy" ]; then
   JAVA_HTTP_PROXY_OPTIONS="$JAVA_HTTP_PROXY_OPTIONS $proxy"
 fi
 
-JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS $JAVA_HTTP_PROXY_OPTIONS"
+if [[ -z "${JAVA_FIPS_OPTIONS}" ]]; then
+  JAVA_FIPS_OPTIONS="-Dcom.redhat.fips=false"
+fi
+
+JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS $JAVA_FIPS_OPTIONS $JAVA_HTTP_PROXY_OPTIONS"
 
 # Deal with embedded escaped spaces in JENKINS_JAVA_OVERRIDES.
 # JENKINS_JAVA_OVERRIDES='-Dfoo -Dbar' => append -Dfoo -Dbar to java invocation

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 | `AGENT_BASE_IMAGE`	|	Setting this value overrides the image used for the 'jnlp' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'jenkins-agent-base:latest' ImageStreamTag in the 'openshift' namespace is used.	|
 | `JAVA_BUILDER_IMAGE`	|	Setting this value overrides the image used for the 'java-builder' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'java:latest' ImageStreamTag in the 'openshift' namespace is used.	|
 | `NODEJS_BUILDER_IMAGE`	|	Setting this value overrides the image used for the 'nodejs-builder' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'nodejs:latest' ImageStreamTag in the 'openshift' namespace is used.	|
+| `JAVA_FIPS_OPTIONS`  | Per this [OpenJDK support article](https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk) control how the JVM operates when running on a FIPS node. |
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 

--- a/openshift/templates/jenkins-ephemeral-monitored.json
+++ b/openshift/templates/jenkins-ephemeral-monitored.json
@@ -154,6 +154,10 @@
                   {
                     "name": "CASC_JENKINS_CONFIG",
                     "value": "/var/lib/jenkins/proxy.yaml"
+                  },
+                  {
+                    "name": "JAVA_FIPS_OPTIONS",
+                    "value": "${JAVA_FIPS_OPTIONS}"
                   }
                 ],
                 "resources": {
@@ -347,6 +351,12 @@
       "displayName": "Disable memory intensive administrative monitors",
       "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
       "value": "false"
+    },
+    {
+      "name": "JAVA_FIPS_OPTIONS",
+      "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
+      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "value": "-Dcom.redhat.fips=false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",

--- a/openshift/templates/jenkins-ephemeral.json
+++ b/openshift/templates/jenkins-ephemeral.json
@@ -154,6 +154,10 @@
                   {
                     "name": "CASC_JENKINS_CONFIG",
                     "value": "/var/lib/jenkins/proxy.yaml"
+                  },
+                  {
+                    "name": "JAVA_FIPS_OPTIONS",
+                    "value": "${JAVA_FIPS_OPTIONS}"
                   }
                 ],
                 "resources": {
@@ -315,6 +319,12 @@
       "displayName": "Disable memory intensive administrative monitors",
       "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
       "value": "false"
+    },
+    {
+      "name": "JAVA_FIPS_OPTIONS",
+      "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
+      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "value": "-Dcom.redhat.fips=false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",

--- a/openshift/templates/jenkins-persistent-monitored.json
+++ b/openshift/templates/jenkins-persistent-monitored.json
@@ -175,6 +175,10 @@
                   {
                     "name": "CASC_JENKINS_CONFIG",
                     "value": "/var/lib/jenkins/proxy.yaml"
+                  },
+                  {
+                    "name": "JAVA_FIPS_OPTIONS",
+                    "value": "${JAVA_FIPS_OPTIONS}"
                   }
                 ],
                 "resources": {
@@ -375,6 +379,12 @@
       "displayName": "Disable memory intensive administrative monitors",
       "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
       "value": "false"
+    },
+    {
+      "name": "JAVA_FIPS_OPTIONS",
+      "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
+      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "value": "-Dcom.redhat.fips=false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",

--- a/openshift/templates/jenkins-persistent.json
+++ b/openshift/templates/jenkins-persistent.json
@@ -175,6 +175,10 @@
                   {
                     "name": "CASC_JENKINS_CONFIG",
                     "value": "/var/lib/jenkins/proxy.yaml"
+                  },
+                  {
+                    "name": "JAVA_FIPS_OPTIONS",
+                    "value": "${JAVA_FIPS_OPTIONS}"
                   }
                 ],
                 "resources": {
@@ -343,6 +347,12 @@
       "displayName": "Disable memory intensive administrative monitors",
       "description": "Whether to perform memory intensive, possibly slow, synchronization with the Jenkins Update Center on start.  If true, the Jenkins core update monitor and site warnings monitor are disabled.",
       "value": "false"
+    },
+    {
+      "name": "JAVA_FIPS_OPTIONS",
+      "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
+      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "value": "-Dcom.redhat.fips=false"
     },
     {
       "name": "JENKINS_IMAGE_STREAM_TAG",

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -193,8 +193,12 @@ if [[ $(echo "$@" | awk '{print NF}') -gt 1 ]]; then
     JAVA_CORE_LIMIT="-XX:ParallelGCThreads=${CONTAINER_CORE_LIMIT} -Djava.util.concurrent.ForkJoinPool.common.parallelism=${CONTAINER_CORE_LIMIT} -XX:CICompilerCount=2"
   fi
 
+  if [[ -z "${JAVA_FIPS_OPTIONS}" ]]; then
+    JAVA_FIPS_OPTIONS="-Dcom.redhat.fips=false"
+  fi
+
   if [[ -z "${JNLP_JAVA_OPTIONS}" ]]; then
-    JNLP_JAVA_OPTIONS="$JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS"
+    JNLP_JAVA_OPTIONS="$JAVA_FIPS_OPTIONS $JAVA_GC_OPTS $JAVA_INITIAL_HEAP_PARAM $JAVA_MAX_HEAP_PARAM $JAVA_CORE_LIMIT $JAVA_DIAGNOSTICS"
   fi
 
   # Deal with embedded escaped spaces in JNLP_JAVA_OVERRIDES.


### PR DESCRIPTION
without defaulting so, none of our Jenkins related JVMs will come up on a FIPS enabled node, failing with something like

```
SEVERE: FIPS mode: only SunJSSE TrustManagers may be used
java.security.KeyManagementException: FIPS mode: only SunJSSE TrustManagers may be used
    at java.base/sun.security.ssl.SSLContextImpl.chooseTrustManager(SSLContextImpl.java:133)
    at java.base/sun.security.ssl.SSLContextImpl.engineInit(SSLContextImpl.java:95)
    at java.base/javax.net.ssl.SSLContext.init(SSLContext.java:297)

```
