### PR TITLE
JKNS-289: complete switch from ocp payload to cpaas images for both jenkins and base agent ocp images

### DIFF
--- a/openshift/imagestreams/jenkins-agent-base-rhel.json
+++ b/openshift/imagestreams/jenkins-agent-base-rhel.json
@@ -17,7 +17,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0-1"
+					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0-1650432209"
 				},
 				"referencePolicy": {
 					"type": "Local"
@@ -35,7 +35,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0"
+					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0"
 				},
 				"referencePolicy": {
 					"type": "Local"
@@ -53,7 +53,7 @@
 				},
 				"from": {
 					"kind": "DockerImage",
-					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0"
+					"name": "registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0"
 				},
 				"importPolicy": {
 					"scheduled": true

--- a/openshift/imagestreams/jenkins-agent-base-rhel.yaml
+++ b/openshift/imagestreams/jenkins-agent-base-rhel.yaml
@@ -13,7 +13,7 @@ spec:
       tags: jenkins
     from:
       kind: DockerImage
-      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0-1
+      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0-1650432209
     referencePolicy:
       type: Local
   - name: user-maintained-upgrade
@@ -27,7 +27,7 @@ spec:
       tags: jenkins
     from:
       kind: DockerImage
-      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0
+      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0
     referencePolicy:
       type: Local
   - name: scheduled-upgrade
@@ -40,7 +40,7 @@ spec:
       tags: jenkins
     from:
       kind: DockerImage
-      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.9.0
+      name: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.10.0
     importPolicy:
       scheduled: true
     referencePolicy:

--- a/openshift/imagestreams/jenkins-rhel.json
+++ b/openshift/imagestreams/jenkins-rhel.json
@@ -55,7 +55,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/openshift4/ose-jenkins:v4.10.0-202203141248.p0.g10e9ee3.assembly.stream"
+          "name": "registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0-1650435173"
         },
         "referencePolicy": {
           "type": "Local"
@@ -73,7 +73,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/openshift4/ose-jenkins:v4.10"
+          "name": "registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0"
         },
         "referencePolicy": {
           "type": "Local"
@@ -91,7 +91,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "registry.redhat.io/openshift4/ose-jenkins:v4.10"
+          "name": "registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0"
         },
         "importPolicy": {
           "scheduled": true

--- a/openshift/imagestreams/jenkins-rhel.yaml
+++ b/openshift/imagestreams/jenkins-rhel.yaml
@@ -47,7 +47,7 @@ spec:
       version: 2.x
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-jenkins:v4.10.0-202203141248.p0.g10e9ee3.assembly.stream
+      name: registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0-1650435173
     referencePolicy:
       type: Local
   - name: 'user-maintained-upgrade-redeploy'
@@ -64,7 +64,7 @@ spec:
       version: 2.x
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-jenkins:v4.10
+      name: registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0
     referencePolicy:
       type: Local
   - name: 'scheduled-upgrade-redeploy'
@@ -81,7 +81,7 @@ spec:
       version: 2.x
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-jenkins:v4.10
+      name: registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0
     importPolicy:
       scheduled: true
     referencePolicy:


### PR DESCRIPTION
after this merges, and openshift/library's cron job picks it up, the we'll do the official library sync for jenkins in https://github.com/openshift/cluster-samples-operator/pull/416 and be done with OCP for this

/assign @coreydaley 
/assign @akram 
/assign @jkhelil 