### PR TITLE
JNKS-287: cannot use specific image refs with okd; quay.io prunes too often

### DIFF
--- a/openshift/imagestreams/jenkins-centos.json
+++ b/openshift/imagestreams/jenkins-centos.json
@@ -55,7 +55,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "quay.io/openshift/origin-jenkins@sha256:1c74f4727908c9455aafb0b0ebfecfd9dddc30b3383a81c3eb834aeddc784cbd"
+          "name": "quay.io/openshift/origin-jenkins:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
long term if we need this for okd we'll push permanent tags to quay.io/redhat-developer