### PR TITLE
JNKS-289: return agent-maven / agent-nodejs imagestreams

### DIFF
--- a/openshift/imagestreams/jenkins-agent-maven-ocp.json
+++ b/openshift/imagestreams/jenkins-agent-maven-ocp.json
@@ -1,0 +1,48 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "jenkins-agent-maven",
+    "annotations": {
+      "openshift.io/display-name": "Jenkins Maven Agent"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins Maven Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with Maven tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "v4.0"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "v4.0",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins Maven Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with Maven tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/openshift4/ose-jenkins-agent-maven:v4.10"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/openshift/imagestreams/jenkins-agent-maven-okd.json
+++ b/openshift/imagestreams/jenkins-agent-maven-okd.json
@@ -1,0 +1,48 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "jenkins-agent-maven",
+    "annotations": {
+      "openshift.io/display-name": "Jenkins Maven Agent"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins Maven Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with Maven tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "v4.0"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "v4.0",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins Maven Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with Maven tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift/origin-jenkins-agent-maven:4.10"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/openshift/imagestreams/jenkins-agent-nodejs-ocp.json
+++ b/openshift/imagestreams/jenkins-agent-nodejs-ocp.json
@@ -1,0 +1,48 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "jenkins-agent-nodejs",
+    "annotations": {
+      "openshift.io/display-name": "Jenkins NodeJS Agent"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins NodeJS Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with NodeJS tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "v4.0"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "v4.0",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins NodeJS Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with NodeJS tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/openshift4/ose-jenkins-agent-nodejs-12-rhel8:v4.10"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}

--- a/openshift/imagestreams/jenkins-agent-nodejs-okd.json
+++ b/openshift/imagestreams/jenkins-agent-nodejs-okd.json
@@ -1,0 +1,48 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "jenkins-agent-nodejs",
+    "annotations": {
+      "openshift.io/display-name": "Jenkins NodeJS Agent"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins NodeJS Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with NodeJS tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "v4.0"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "v4.0",
+        "annotations": {
+          "openshift.io/display-name": "Jenkins NodeJS Agent",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Provides a Jenkins Agent with NodeJS tooling",
+          "iconClass": "icon-jenkins",
+          "tags": "jenkins"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "quay.io/openshift/origin-jenkins-agent-nodejs:4.10"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
We cannot remove them while the images are only deprecated.  We have to wait to remove until the images are EOL.  This corrects my overzealous removal with https://github.com/openshift/jenkins/pull/1414

That said, they now point to the latest 4.10 versions at registry.redhat.io and quay.io, vs. older versions (which were overridden by samples operator).