### PR TITLE
Bug 2096186: Avoid double slashes trailing in remoting.jar

### DIFF
--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -125,8 +125,10 @@ if [[ $(echo "$@" | awk '{print NF}') -gt 1 ]]; then
     fi
   fi
 
-  echo "Downloading ${JENKINS_URL}/jnlpJars/remoting.jar ..."
-  curl -sS ${JENKINS_URL}/jnlpJars/remoting.jar -o ${JAR}
+  # Avoid double slashes in URL
+  # ${string%%substring} Deletes longest match of $substring from back of $string.
+  echo "Downloading ${JENKINS_URL%%/}/jnlpJars/remoting.jar ..."
+  curl -sS ${JENKINS_URL%%/}/jnlpJars/remoting.jar -o ${JAR}
 
   # if -tunnel is not provided try env vars
   if [[ "$@" != *"-tunnel "* ]]; then


### PR DESCRIPTION
Jenkins enforces trailing slash [1] and appending the second one is causing troubles on our OCP clusters when custom OCP route with CNAME is used. Some clients (recent versions of Chrome and curl) that use HTTP/2 fail [2].

[1] https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/model/JenkinsLocationConfiguration.java#L140

[2]
```
Downloading https://<URL>//jnlpJars/remoting.jar ...
curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
```