### PR TITLE
Bug 2095620: Bump matrix-project plugin to 1.20

### DIFF
--- a/2/contrib/jenkins/install-plugins.sh
+++ b/2/contrib/jenkins/install-plugins.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -eu
+#!/bin/bash -eu
 #
 # Originally copied from https://github.com/jenkinsci/docker
 # You can set JENKINS_UC to change the default URL to Jenkins update center

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -19,7 +19,7 @@ junit:1.52
 lockable-resources:2.11
 mapdb-api:1.0.9.0
 matrix-auth:2.6.8
-matrix-project:1.19
+matrix-project:1.20
 mercurial:2.15
 metrics:4.0.2.8
 openshift-client:1.0.35

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -69,7 +69,7 @@ lockable-resources:2.11
 mailer:408.vd726a_1130320
 mapdb-api:1.0.9.0
 matrix-auth:2.6.8
-matrix-project:1.19
+matrix-project:1.20
 maven-plugin:3.7
 mercurial:2.15
 metrics:4.0.2.8


### PR DESCRIPTION
4.10 image is not starting correctly because of incorrect version of matrix-project plugin