### PR TITLE
OCPBUGS-655: Update blueocean-autofavorite to 1.2.5

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -1,5 +1,6 @@
 ant:1.11
 blueocean:1.24.8
+blueocean-autofavorite:1.2.5
 blueocean-pipeline-scm-api:1.25.6
 cloudbees-bitbucket-branch-source:746.v350d2781c184
 cloudbees-folder:6.16

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -4,7 +4,7 @@ ant:1.11
 apache-httpcomponents-client-4-api:4.5.13-1.0
 authentication-tokens:1.4
 blueocean:1.24.8
-blueocean-autofavorite:1.2.4
+blueocean-autofavorite:1.2.5
 blueocean-bitbucket-pipeline:1.24.8
 blueocean-commons:1.25.6
 blueocean-config:1.24.8


### PR DESCRIPTION
Update to newer version which does not use the groovy-sandbox library