### PR TITLE
[release-4.10] OCPBUGS-1037: Install glibc language package to remove `setLocale` warning

### DIFF
--- a/slave-base/Dockerfile.rhel8
+++ b/slave-base/Dockerfile.rhel8
@@ -21,7 +21,7 @@ LABEL com.redhat.component="jenkins-slave-base-rhel7-container" \
       io.k8s.display-name="Jenkins Slave Base" \
       io.k8s.description="The jenkins slave base image is intended to be built on top of, to add your own tools that your jenkins job needs. The slave base image includes all the jenkins logic to operate as a slave, so users just have to yum install any additional packages their specific jenkins job will need" \
       io.openshift.tags="openshift,jenkins,slave" \
-      maintainer="openshift-dev-services+jenkins@redhat.com"      
+      maintainer="openshift-dev-services+jenkins@redhat.com"
 
 
 ENV HOME=/home/jenkins \
@@ -30,7 +30,7 @@ ENV HOME=/home/jenkins \
 
 USER root
 # Install headless Java
-RUN INSTALL_PKGS="bc gettext git java-11-openjdk-headless java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
+RUN INSTALL_PKGS="glibc-langpack-en bc gettext git java-11-openjdk-headless java-1.8.0-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
     yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \
@@ -43,7 +43,7 @@ RUN INSTALL_PKGS="bc gettext git java-11-openjdk-headless java-1.8.0-openjdk-hea
     chmod 775 /usr/bin && \
     chmod 775 /usr/share/man/man1 && \
     mkdir -p /var/lib/origin && \
-    chmod 775 /var/lib/origin && \    
+    chmod 775 /var/lib/origin && \
     unlink /usr/bin/java && \
     unlink /usr/bin/jjs && \
     unlink /usr/bin/keytool && \


### PR DESCRIPTION
Whenever jenkins jobs and commands are run, logs are filled with below warning:
 
 ```
 # podman run -it --entrypoint /bin/bash registry.redhat.io/openshift4/ose-jenkins-agent-base:v4.10.0-202207291908.p0.gc5b7159.assembly.stream 
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8) <---
```

Installing the glibc language package solves the problem.

Bug https://issues.redhat.com/browse/OCPBUGS-1037

Signed-off-by: divyansh42 <diagrawa@redhat.com>