### PR TITLE
OCPBUGS-2099: Force git-server to an earlier version

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -13,6 +13,7 @@ docker-commons:1.18
 favorite:2.4.1
 git:4.11.4
 git-client:3.11.1
+git-server:99.va_0826a_b_cdfa_d
 github:1.34.5
 google-oauth-plugin:1.0.6
 groovy:2.4

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -24,7 +24,7 @@ blueocean-rest:1.25.6
 blueocean-rest-impl:1.24.8
 blueocean-web:1.24.8
 bootstrap5-api:5.1.3-6
-bouncycastle-api:2.25
+bouncycastle-api:2.26
 branch-api:2.7.0
 caffeine-api:2.9.2-29.v717aac953ff3
 checks-api:1.7.4
@@ -47,11 +47,12 @@ git-client:3.11.1
 github:1.34.5
 github-api:1.114.2
 github-branch-source:2.6.0
-git-server:1.10
+git-server:99.va_0826a_b_cdfa_d
 google-oauth-plugin:1.0.6
 groovy:2.4
 handy-uri-templates-2-api:2.1.8-1.0
 htmlpublisher:1.25
+instance-identity:116.vf8f487400980
 jackson2-api:2.13.2.20220328-273.v11d70a_b_a_1a_52
 javadoc:1.0
 javax-activation-api:1.2.0-2
@@ -73,6 +74,8 @@ matrix-project:1.20
 maven-plugin:3.7
 mercurial:2.16.2
 metrics:4.0.2.8.1
+mina-sshd-api-common:2.8.0-18.vd98674ecd652
+mina-sshd-api-core:2.8.0-18.vd98674ecd652
 oauth-credentials:0.4
 okhttp-api:4.9.2-20211102
 openshift-client:1.0.37
@@ -103,7 +106,7 @@ script-security:1175.v4b_d517d6db_f0
 snakeyaml-api:1.30.1
 sse-gateway:1.24
 ssh-credentials:1.19
-sshd:3.0.4
+sshd:3.242.va_db_9da_b_26a_c3
 structs:318.va_f3ccb_729b_71
 subversion:2.15.4
 token-macro:293.v283932a_0a_b_49

--- a/OWNERS
+++ b/OWNERS
@@ -5,10 +5,10 @@ reviewers:
 - waveywaves
 - otaviof
 - sbose78
-- akashshinde
 - jkhelil
 - jitendar-singh
 - coreydaley
+- divyansh42
 
 approvers:
 - bparees
@@ -18,8 +18,7 @@ approvers:
 - waveywaves
 - otaviof
 - sbose78
-- akashshinde
 - jkhelil
 - jitendar-singh
 - coreydaley
-
+- divyansh42


### PR DESCRIPTION
Force git-server to an earlier version  to ensure that we get version of sshd matching the embedded in jenkins 2.361.1