### PR TITLE
OCPBUGS-4094: Various CVEs September/2022

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -38,6 +38,7 @@ pam-auth:1.6
 parameterized-trigger:2.43.1
 pipeline-build-step:2.16
 pipeline-input-step:456.vd8a_957db_5b_e9
+pipeline-rest-api:2.27
 pipeline-utility-steps:2.12.0
 prometheus:2.0.10
 scm-api:621.vda_a_b_055e58f7

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -3,7 +3,7 @@ blueocean:1.25.8
 blueocean-autofavorite:1.2.5
 blueocean-pipeline-scm-api:1.25.8
 cloudbees-bitbucket-branch-source:791.vb_eea_a_476405b
-cloudbees-folder:6.16
+cloudbees-folder:6.729.v2b_9d1a_74d673
 config-file-provider:3.8.1
 configuration-as-code-groovy:1.1
 configuration-as-code:1512.vb_79d418d5fc8
@@ -37,6 +37,7 @@ openshift-sync:1.0.55
 pam-auth:1.6
 parameterized-trigger:2.43.1
 pipeline-build-step:2.16
+pipeline-groovy-lib:612.614.v48dcb_f62a_640
 pipeline-input-step:456.vd8a_957db_5b_e9
 pipeline-rest-api:2.27
 pipeline-utility-steps:2.12.0

--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -29,6 +29,8 @@ matrix-project:785.v06b_7f47b_c631
 maven-plugin:3.20
 mercurial:2.16.2
 metrics:4.0.2.8.1
+mina-sshd-api-common:2.9.2-50.va_0e1f42659a_a
+mina-sshd-api-core:2.9.2-50.va_0e1f42659a_a
 openshift-client:1.0.38
 openshift-login:1.0.29
 openshift-sync:1.0.55

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -95,8 +95,8 @@ pipeline-milestone-step:1.3.2
 pipeline-model-api:1.9.3
 pipeline-model-definition:1.9.2
 pipeline-model-extensions:1.9.3
-pipeline-rest-api:2.15
-pipeline-stage-step:2.5
+pipeline-rest-api:2.27
+pipeline-stage-step:293.v200037eefcd5
 pipeline-stage-tags-metadata:1.9.2
 pipeline-utility-steps:2.12.0
 plain-credentials:139.ved2b_9cf7587b

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -25,11 +25,11 @@ blueocean-rest-impl:1.25.8
 blueocean-web:1.25.8
 bootstrap5-api:5.1.3-6
 bouncycastle-api:2.26
-branch-api:2.7.0
+branch-api:2.1046.v0ca_37783ecc5
 caffeine-api:2.9.3-65.v6a_47d0f4d1fe
 checks-api:1.7.4
 cloudbees-bitbucket-branch-source:791.vb_eea_a_476405b
-cloudbees-folder:6.16
+cloudbees-folder:6.729.v2b_9d1a_74d673
 conditional-buildstep:1.4.1
 config-file-provider:3.8.1
 configuration-as-code:1512.vb_79d418d5fc8
@@ -89,7 +89,7 @@ pam-auth:1.6
 parameterized-trigger:2.43.1
 pipeline-build-step:2.16
 pipeline-graph-analysis:1.11
-pipeline-groovy-lib:589.vb_a_b_4a_a_8c443c
+pipeline-groovy-lib:612.614.v48dcb_f62a_640
 pipeline-input-step:456.vd8a_957db_5b_e9
 pipeline-milestone-step:1.3.2
 pipeline-model-api:1.9.3
@@ -115,7 +115,7 @@ structs:324.va_f5d6774f3a_d
 subversion:2.15.4
 token-macro:308.v4f2b_ed62b_b_16
 trilead-api:1.67.vc3938a_35172f
-variant:1.4
+variant:59.vf075fe829ccb
 workflow-api:1192.v2d0deb_19d212
 workflow-basic-steps:2.20
 workflow-cps:2803.v1a_f77ffcc773

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -78,8 +78,8 @@ matrix-project:785.v06b_7f47b_c631
 maven-plugin:3.20
 mercurial:2.16.2
 metrics:4.0.2.8.1
-mina-sshd-api-common:2.8.0-18.vd98674ecd652
-mina-sshd-api-core:2.8.0-18.vd98674ecd652
+mina-sshd-api-common:2.9.2-50.va_0e1f42659a_a
+mina-sshd-api-core:2.9.2-50.va_0e1f42659a_a
 oauth-credentials:0.4
 okhttp-api:4.9.2-20211102
 openshift-client:1.0.38


### PR DESCRIPTION
- CVE-2022-43405: `pipeline-groovy-lib` bumped to `612.614.v48dcb_f62a_640`
- CVE-2022-43402: `workflow-cps` bumped to `2803.v1a_f77ffcc773`
- CVE-2022-43407: `pipeline-input-step` bumped to `456.vd8a_957db_5b_e9`
- CVE-2022-43408: `pipeline-rest-api` bumped to `2.27`
- CVE-2022-43409: `workflow-support` bumped to `839.v35e2736cfd5c`
- CVE-2022-43403, CVE-2022-43404, CVE-2022-43401:  `script-security` bumped to `1184.v85d16b_d851b_3`
- CVE-2022-45047: `mina-sshd-api-{core,common}` bumped to `2.9.2-50.va_0e1f42659a_a`
- CVE-2022-43406: `workflow-cps-global-lib` already on `588.v576c103a_ff86`
- CVE-2022-25857: `snakeyaml-api` already on `1.32-86.ve3f030a_75631`
- CVE-2022-30954, CVE-2022-30953: `blueocean` already on `1.25.8`
- CVE-2021-26291: not applicable