### PR TITLE
OCPBUGS-8437: Fix labels for jenkins-slave-base-rhel8

### DIFF
--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -50,7 +50,7 @@ LABEL io.k8s.description="Jenkins is a continuous integration server" \
 
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="openshift-jenkins-2-container" \
-      name="openshift4/jenkins-2-rhel7" \
+      name="openshift4/jenkins-2-rhel8" \
       architecture="x86_64 \
       maintainer="openshift-dev-services+jenkins@redhat.com""
 

--- a/agent-maven/Dockerfile.rhel8
+++ b/agent-maven/Dockerfile.rhel8
@@ -2,8 +2,8 @@ FROM registry.ci.openshift.org/ocp/4.11:jenkins-agent-base
 MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
 
 # Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-agent-maven-35-rhel7-container" \
-      name="openshift4/jenkins-agent-maven-35-rhel7" \
+LABEL com.redhat.component="jenkins-agent-maven-35-rhel8-container" \
+      name="openshift4/jenkins-agent-maven-35-rhel8" \
       architecture="x86_64" \
       io.k8s.display-name="Jenkins Agent Maven" \
       io.k8s.description="The jenkins agent maven image has the maven tools on top of the jenkins slave base image." \

--- a/agent-nodejs-10/Dockerfile.rhel8
+++ b/agent-nodejs-10/Dockerfile.rhel8
@@ -3,8 +3,8 @@ FROM registry.ci.openshift.org/ocp/4.8:jenkins-agent-base
 MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
 
 # Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-agent-nodejs-10-rhel7-container" \
-      name="openshift4/jenkins-agent-nodejs-10-rhel7" \
+LABEL com.redhat.component="jenkins-agent-nodejs-10-rhel8-container" \
+      name="openshift4/jenkins-agent-nodejs-10-rhel8" \
       architecture="x86_64" \
       io.k8s.display-name="Jenkins Agent Nodejs" \
       io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins slave base image." \

--- a/agent-nodejs-12/Dockerfile.rhel8
+++ b/agent-nodejs-12/Dockerfile.rhel8
@@ -3,8 +3,8 @@ FROM registry.ci.openshift.org/ocp/4.13:jenkins-agent-base
 MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.com>
 
 # Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-agent-nodejs-12-rhel7-container" \
-      name="openshift4/jenkins-agent-nodejs-12-rhel7" \
+LABEL com.redhat.component="jenkins-agent-nodejs-12-rhel8-container" \
+      name="openshift4/jenkins-agent-nodejs-12-rhel8" \
       architecture="x86_64" \
       io.k8s.display-name="Jenkins Agent Nodejs" \
       io.k8s.description="The jenkins agent nodejs image has the nodejs tools on top of the jenkins slave base image." \

--- a/slave-base/Dockerfile.rhel8
+++ b/slave-base/Dockerfile.rhel8
@@ -15,8 +15,8 @@ MAINTAINER OpenShift Developer Services <openshift-dev-services+jenkins@redhat.c
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 
 # Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-slave-base-rhel7-container" \
-      name="openshift4/jenkins-slave-base-rhel7" \
+LABEL com.redhat.component="jenkins-slave-base-rhel8-container" \
+      name="openshift4/jenkins-slave-base-rhel8" \
       architecture="x86_64" \
       io.k8s.display-name="Jenkins Slave Base" \
       io.k8s.description="The jenkins slave base image is intended to be built on top of, to add your own tools that your jenkins job needs. The slave base image includes all the jenkins logic to operate as a slave, so users just have to yum install any additional packages their specific jenkins job will need" \


### PR DESCRIPTION
`slave-base/Dockerfile.rhel8` should label with rhel8, which is labeled with rhel7 currently.