### PR TITLE
OCPBUGS-2541: `configuration-as-code` bumped to `1569.vb_72405b_80249`

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -4,9 +4,11 @@ blueocean-autofavorite:1.2.5
 blueocean-pipeline-scm-api:1.25.8
 cloudbees-bitbucket-branch-source:791.vb_eea_a_476405b
 cloudbees-folder:6.740.ve4f4ffa_dea_54
+commons-lang3-api:3.12.0-36.vd97de6465d5b_
+commons-text-api:1.10.0-36.vc008c8fcda_7b_
 config-file-provider:3.8.1
 configuration-as-code-groovy:1.1
-configuration-as-code:1512.vb_79d418d5fc8
+configuration-as-code:1569.vb_72405b_80249
 credentials:1189.vf61b_a_5e2f62e
 credentials-binding:523.vd859a_4b_122e6
 docker-commons:1.18
@@ -43,9 +45,9 @@ pipeline-utility-steps:2.14.0
 pipeline-stage-view:2.27
 prometheus:2.0.10
 scm-api:621.vda_a_b_055e58f7
-script-security:1218.v39ca_7f7ed0a_c
+script-security:1229.v4880b_b_e905a_6
 snakeyaml-api:1.33-90.v80dcb_3814d35
-ssh-credentials:277.280.v1e86b_7d0056b_
+ssh-credentials:305.v8f4381501156
 subversion:2.15.4
 token-macro:308.v4f2b_ed62b_b_16
 workflow-api:1200.v8005c684b_a_c6

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -30,11 +30,11 @@ caffeine-api:2.9.3-65.v6a_47d0f4d1fe
 checks-api:1.8.0
 cloudbees-bitbucket-branch-source:791.vb_eea_a_476405b
 cloudbees-folder:6.740.ve4f4ffa_dea_54
-commons-lang3-api:3.12.0.0
-commons-text-api:1.9-9.v39a_53e2e0343
+commons-lang3-api:3.12.0-36.vd97de6465d5b_
+commons-text-api:1.10.0-36.vc008c8fcda_7b_
 conditional-buildstep:1.4.1
 config-file-provider:3.8.1
-configuration-as-code:1512.vb_79d418d5fc8
+configuration-as-code:1569.vb_72405b_80249
 configuration-as-code-groovy:1.1
 credentials:1189.vf61b_a_5e2f62e
 credentials-binding:523.vd859a_4b_122e6
@@ -110,10 +110,10 @@ prometheus:2.0.10
 pubsub-light:1.16
 run-condition:1.3
 scm-api:621.vda_a_b_055e58f7
-script-security:1218.v39ca_7f7ed0a_c
+script-security:1229.v4880b_b_e905a_6
 snakeyaml-api:1.33-90.v80dcb_3814d35
 sse-gateway:1.24
-ssh-credentials:277.280.v1e86b_7d0056b_
+ssh-credentials:305.v8f4381501156
 sshd:3.242.va_db_9da_b_26a_c3
 structs:324.va_f5d6774f3a_d
 subversion:2.15.4


### PR DESCRIPTION
Cyclic dependecy issue found, updating the following:

- ssh-credentials: 305.v8f4381501156
- commons-lang3-api: 3.12.0-36.vd97de6465d5b_
- commons-text-api: 1.10.0-36.vc008c8fcda_7b_