### PR TITLE
OCPBUGS-11158,OCPBUGS-7575,OCPBUGS-7572: Various issues

### DIFF
--- a/2/contrib/openshift/base-plugins.txt
+++ b/2/contrib/openshift/base-plugins.txt
@@ -12,6 +12,7 @@ configuration-as-code:1569.vb_72405b_80249
 credentials:1189.vf61b_a_5e2f62e
 credentials-binding:523.vd859a_4b_122e6
 docker-commons:1.18
+email-ext:2.90
 favorite:2.4.1
 git:4.12.1
 git-client:3.11.1
@@ -23,8 +24,9 @@ htmlpublisher:1.25
 javax-mail-api:1.6.2-6
 jira:3.7.1
 job-dsl:1.77
-junit:1166.va_436e268e972
+junit:1166.1168.vd6b_8042a_06de
 lockable-resources:2.11
+mailer:435.v79ef3972b_5c7
 mapdb-api:1.0.9.0
 matrix-auth:3.1.5
 matrix-project:785.v06b_7f47b_c631
@@ -38,7 +40,7 @@ openshift-login:1.0.29
 openshift-sync:1.0.55
 pam-auth:1.6
 parameterized-trigger:2.43.1
-pipeline-build-step:2.16
+pipeline-build-step:2.18.1
 pipeline-groovy-lib:621.vb_44ce045b_582
 pipeline-input-step:456.vd8a_957db_5b_e9
 pipeline-utility-steps:2.14.0
@@ -51,6 +53,7 @@ ssh-credentials:305.v8f4381501156
 subversion:2.15.4
 token-macro:308.v4f2b_ed62b_b_16
 workflow-api:1200.v8005c684b_a_c6
+workflow-basic-steps:980.v82219a_ed188e
 workflow-cps:3536.vb_8a_6628079d5
 workflow-cps-global-lib:609.vd95673f149b_b
 workflow-multibranch:716.vc692a_e52371b_

--- a/2/contrib/openshift/bundle-plugins.txt
+++ b/2/contrib/openshift/bundle-plugins.txt
@@ -40,8 +40,9 @@ credentials:1189.vf61b_a_5e2f62e
 credentials-binding:523.vd859a_4b_122e6
 display-url-api:2.3.6
 docker-commons:1.18
-durable-task:493.v195aefbb0ff2
+durable-task:496.va67c6f9eefa7
 echarts-api:5.4.0-1
+email-ext:2.90
 favorite:2.4.1
 font-awesome-api:6.1.2-1
 git:4.12.1
@@ -68,7 +69,7 @@ jira:3.7.1
 job-dsl:1.77
 jquery3-api:3.6.0-4
 jsch:0.1.55.2
-junit:1166.va_436e268e972
+junit:1166.1168.vd6b_8042a_06de
 kubernetes:1.31.0
 kubernetes-client-api:5.10.1-171.vaa0774fb8c20
 kubernetes-credentials:0.9.0
@@ -90,7 +91,7 @@ openshift-login:1.0.29
 openshift-sync:1.0.55
 pam-auth:1.6
 parameterized-trigger:2.43.1
-pipeline-build-step:2.16
+pipeline-build-step:2.18.1
 pipeline-graph-analysis:1.11
 pipeline-groovy-lib:621.vb_44ce045b_582
 pipeline-input-step:456.vd8a_957db_5b_e9
@@ -121,11 +122,11 @@ token-macro:308.v4f2b_ed62b_b_16
 trilead-api:1.67.vc3938a_35172f
 variant:59.vf075fe829ccb
 workflow-api:1200.v8005c684b_a_c6
-workflow-basic-steps:2.20
+workflow-basic-steps:980.v82219a_ed188e
 workflow-cps:3536.vb_8a_6628079d5
 workflow-cps-global-lib:609.vd95673f149b_b
-workflow-durable-task-step:2.40
-workflow-job:1145.v7f2433caa07f
+workflow-durable-task-step:1164.v2334ddcf48d0
+workflow-job:1189.va_d37a_e9e4eda_
 workflow-multibranch:716.vc692a_e52371b_
 workflow-scm-step:400.v6b_89a_1317c9a_
 workflow-step-api:639.v6eca_cd8c04a_a_


### PR DESCRIPTION


Mitigates:
 - https://github.com/advisories/GHSA-9j65-3f2q-8q2r
 - https://github.com/advisories/GHSA-ph74-8rgx-64c5

Fixes Mailer plugin breaking update issue
Breaking changes

    Migrate to Jakarta Mail (https://github.com/jenkinsci/mailer-plugin/pull/144) @basil

Related plugin releases

The following plugins must be upgraded in lockstep:

    [Mailer 435.v79ef3972b_5c7](https://github.com/jenkinsci/mailer-plugin/releases/tag/435.v79ef3972b_5c7)
    [Pipeline: Basic Steps 980.v82219a_ed188e](https://github.com/jenkinsci/workflow-basic-steps-plugin/releases/tag/980.v82219a_ed188e)
    [Email Extension 2.90](https://github.com/jenkinsci/email-ext-plugin/releases/tag/email-ext-2.90)

Failure to upgrade all three plugins in lockstep will result in linkage errors.

https://github.com/jenkinsci/mailer-plugin/releases/tag/435.v79ef3972b_5c7