### PR TITLE
[JKNS-344] Second phase of self-verification process for Jenkins

### DIFF
--- a/scripts/verify-jenkins-on-openshift.sh
+++ b/scripts/verify-jenkins-on-openshift.sh
@@ -2,45 +2,62 @@
 
 # This script deploys the jenkins pod with provided image (from CPaas) on an 
 # OpenShift cluster & executes verify_jenkins.sh within the newly deployed pod.
+# 
+# Prerequisites:
+# Ensure a login to OpenShift cluster, either via user:password, token
+# OR
+# KUBECONFIG env var refers to a valid kubeconfig
+# 
+# Usage: ./verify-jenkins-on-openshift.sh [-i <jenkins_image>] [-s <commit_sha>]
+# 
+
 set -o pipefail
 
-# Takes input & stores in the respective variables
-# 
-get_input(){
-    read -p "OpenShift's API URL: " API_SERVER
-    read -p "OpenShift's User Name (kubeadmin): " USER_NAME
-    read -p "OpenShift's User Password: " USER_PASSWORD
-    read -p "Jenkins Image built by CPaas: " JENKINS_IMAGE  
+# returns the details about command usage
+usage() { 
+    printf "Usage: ./verify-jenkins-on-openshift.sh [-i <jenkins_image>] [-s <commit_sha>]\n"
+    printf "Pre-requisite: Ensure that a user is already logged in the cluster OR have a valid KUBECONFIG populated\n" 
+    exit 1; 
 }
 
-vars(){
+# Assigns the variable values as per the flags passed.
+while getopts "i:s:*:" flag
+do
+    case "${flag}" in
+        i) JENKINS_IMAGE=${OPTARG};;
+        s) COMMIT_SHA=${OPTARG};;
+        *) usage
+    esac
+done
 
-    get_input
-    IFS=":" read -r IMG TAG <<< ${JENKINS_IMAGE}
-    QUAY_IMAGE="quay.io/pipeline-integrations/openshift-ose-jenkins:${TAG}"
+# Verifies & sets the required values for variables.
+# 
+vars(){   
 
-    # if username is not passed, pick `kubeadmin` as default user
-    if [ -z ${USER_NAME} ]
+    if [ -z "${JENKINS_IMAGE}" ] || [ -z "${COMMIT_SHA}" ]
     then
-        USER_NAME="kubeadmin"
+        usage
     fi
+
+    # The image pushed will have the respective commit's sha assigned as the tag
+    QUAY_IMAGE="quay.io/pipeline-integrations/openshift-ose-jenkins:${COMMIT_SHA}"
 }
 
 # get_image_ready() 
 # pulls the brew image locally, tags & pushes it to quay.
 # 
 get_image_ready(){
-    echo -e "\n-------------------------------------------------------\n>INFO || Pulling the Jenkins Image\n"
-    IMAGE_ID=$(podman pull ${JENKINS_IMAGE})
-    if [ -z $IMAGE_ID ]
+    printf "\n-------------------------------------------------------\n>INFO || Pulling the Jenkins Image\n"
+    IMAGE_ID=$(podman pull "${JENKINS_IMAGE}")
+    if [ -z "${IMAGE_ID}" ]
     then
-        echo -e "\n>ERR =======> Image Pull Failed\n"
+        printf "\n>ERR || Image Pull Failed\n"
         exit 1
     else
-        podman tag ${JENKINS_IMAGE} ${QUAY_IMAGE}
-        echo -e "\n-------------------------------------------------------\n>INFO || Pushing the image to quay.io/pipeline-integrations\n"
-        podman push ${QUAY_IMAGE}
-        echo -e "\n-------------------------------------------------------\n>INFO || Image push successful\n"
+        podman tag "${JENKINS_IMAGE}" "${QUAY_IMAGE}"
+        printf "\n-------------------------------------------------------\n>INFO || Pushing the image to 'quay.io/pipeline-integrations'\n"
+        podman push "${QUAY_IMAGE}"
+        printf "\n-------------------------------------------------------\n>INFO || Image %s pushed successful\n" "${QUAY_IMAGE}"
     fi
 }
 
@@ -53,32 +70,30 @@ deploy_on_openshift(){
     oc version > /dev/null
     if [ $? != 0 ]
     then
-        echo "\n-------------------------------------------------------> Please install `oc` client to continue. https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/"
+        printf "\n ERR || Please install 'oc' client to continue. https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/"
         exit 1
     fi
 
     # if oc exists, continue
-    echo -e "\n-------------------------------------------------------\n>INFO || Logging in as " ${USER_NAME} " to " ${API_SERVER} "\n"
-    oc login -u ${USER_NAME} -p ${USER_PASSWORD} ${API_SERVER}
     oc delete project test-jenkins-latest
     oc new-project test-jenkins-latest
-    oc import-image --confirm jenkins-image --from=${QUAY_IMAGE}
-    oc new-app jenkins-ephemeral -p NAMESPACE=$(oc project -q) -p JENKINS_IMAGE_STREAM_TAG=jenkins-image:latest
+    oc import-image --confirm jenkins-image --from="${QUAY_IMAGE}"
+    oc new-app jenkins-ephemeral -p NAMESPACE="$(oc project -q)" -p JENKINS_IMAGE_STREAM_TAG=jenkins-image:latest
 
     # wait for jenkins pod to switch to 'Ready' & 'Running` state:
     sleep 10
-    echo -e "\n-------------------------------------------------------\n>INFO || Waiting for pod to be ready\n"
+    printf "\n-------------------------------------------------------\n>INFO || Waiting for pod to be ready\n"
     OUTPUT=$(oc wait pod --for=condition=Ready -l name=jenkins,deploymentconfig=jenkins --timeout=120s)
 
     if [ -z "${OUTPUT}" ]
     then
         exit 1
     else
-        IFS=" " read -ra ELEMENTS <<< ${OUTPUT}
-        IFS="/" read -r POD POD_NAME <<< ${ELEMENTS[0]}
+        IFS=" " read -ra ELEMENTS <<< "${OUTPUT}"
+        IFS="/" read -r POD POD_NAME <<< "${ELEMENTS[0]}"
     fi
 
-    echo -e "\n-------------------------------------------------------\n>INFO || Pod ${POD_NAME} is available now\n"    
+    printf "\n-------------------------------------------------------\n>INFO || Pod %s is available now\n" "${POD_NAME}"    
 }
 
 # Creates '/tmp/download_script.sh' script which is executed within the pod.
@@ -87,23 +102,23 @@ deploy_on_openshift(){
 execute_verification_script(){
 
     # Create a script, that'll execute the `verify-jenkins.sh` within the pod
-    read -e -p "Enter the relevant commit's SHA: " COMMIT_SHA
+    # read -e -p "Enter the relevant commit's COMMIT_SHA: " COMMIT_SHA
     cat > /tmp/download_script.sh << EOL
-curl https://raw.githubusercontent.com/openshift/jenkins/master/scripts/verify-jenkins.sh | SHA=$COMMIT_SHA sh
+curl https://raw.githubusercontent.com/openshift/jenkins/master/scripts/verify-jenkins.sh | SHA=${COMMIT_SHA} sh
 EOL
 
     # Run jenkins verification script inside the pod & redirect the output to a file.
-    echo -e "\n-------------------------------------------------------\n>INFO || Running the verify-jenkins.sh within the pod\n"
-    oc exec -i $POD_NAME -- bash -s < /tmp/download_script.sh &> /tmp/result.out
+    printf "\n-------------------------------------------------------\n>INFO || Running the verify-jenkins.sh within the pod\n"
+    oc exec -i "$POD_NAME" -- bash -s < /tmp/download_script.sh &> /tmp/result.out
 
     # Check if "All tests succeeded" string exists in the file.
     if [ "$(grep "All tests succeeded" /tmp/result.out)" == "" ]
     then
         grep "Jenkins startup" /tmp/result.out -A 3
-        echo -e "\n>>> ERR || Check /tmp/result.out on local machine for details\n"
+        printf "\n>>> ERR || Check /tmp/result.out on local machine for details\n"
         exit 1
     else
-        echo -e "=== All tests succeeded ==="
+        printf "=== All tests succeeded ==="
     fi
 }
 

--- a/scripts/verify-jenkins-on-openshift.sh
+++ b/scripts/verify-jenkins-on-openshift.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# This script deploys the jenkins pod with provided image (from CPaas) on an 
-# OpenShift cluster & executes verify_jenkins.sh within the newly deployed pod.
+# This script spins up a container from provided jenkins (CPaas) image 
+# & runs `verify_jenkins.sh` in it.
+# If all tests pass, it deploys a jenkins pod with the same image on an 
+# OpenShift cluster & informs once the pod is available to run e2e tests against it.
 # 
 # Prerequisites:
 # Ensure a login to OpenShift cluster, either via user:password, token
@@ -44,7 +46,7 @@ vars(){
 }
 
 # deploy_on_openshift()
-# Deploys the pod with the provided CPaas image, 
+# Deploys the pod with the provided CPaas image.
 # 
 deploy_on_openshift(){
 

--- a/scripts/verify-jenkins-on-openshift.sh
+++ b/scripts/verify-jenkins-on-openshift.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# This script deploys the jenkins pod with provided image (from CPaas) on an 
+# OpenShift cluster & executes verify_jenkins.sh within the newly deployed pod.
+set -o pipefail
+
+# Takes input & stores in the respective variables
+# 
+get_input(){
+    read -p "OpenShift's API URL: " API_SERVER
+    read -p "OpenShift's User Name (kubeadmin): " USER_NAME
+    read -p "OpenShift's User Password: " USER_PASSWORD
+    read -p "Jenkins Image built by CPaas: " JENKINS_IMAGE  
+}
+
+vars(){
+
+    get_input
+    IFS=":" read -r IMG TAG <<< ${JENKINS_IMAGE}
+    QUAY_IMAGE="quay.io/pipeline-integrations/openshift-ose-jenkins:${TAG}"
+
+    # if username is not passed, pick `kubeadmin` as default user
+    if [ -z ${USER_NAME} ]
+    then
+        USER_NAME="kubeadmin"
+    fi
+}
+
+# get_image_ready() 
+# pulls the brew image locally, tags & pushes it to quay.
+# 
+get_image_ready(){
+    echo -e "\n-------------------------------------------------------\n>INFO || Pulling the Jenkins Image\n"
+    IMAGE_ID=$(podman pull ${JENKINS_IMAGE})
+    if [ -z $IMAGE_ID ]
+    then
+        echo -e "\n>ERR =======> Image Pull Failed\n"
+        exit 1
+    else
+        podman tag ${JENKINS_IMAGE} ${QUAY_IMAGE}
+        echo -e "\n-------------------------------------------------------\n>INFO || Pushing the image to quay.io/pipeline-integrations\n"
+        podman push ${QUAY_IMAGE}
+        echo -e "\n-------------------------------------------------------\n>INFO || Image push successful\n"
+    fi
+}
+
+# deploy_on_openshift()
+# Deploys the pod with the provided CPaas image, 
+# 
+deploy_on_openshift(){
+
+    # ensure oc exists
+    oc version > /dev/null
+    if [ $? != 0 ]
+    then
+        echo "\n-------------------------------------------------------> Please install `oc` client to continue. https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/"
+        exit 1
+    fi
+
+    # if oc exists, continue
+    echo -e "\n-------------------------------------------------------\n>INFO || Logging in as " ${USER_NAME} " to " ${API_SERVER} "\n"
+    oc login -u ${USER_NAME} -p ${USER_PASSWORD} ${API_SERVER}
+    oc delete project test-jenkins-latest
+    oc new-project test-jenkins-latest
+    oc import-image --confirm jenkins-image --from=${QUAY_IMAGE}
+    oc new-app jenkins-ephemeral -p NAMESPACE=$(oc project -q) -p JENKINS_IMAGE_STREAM_TAG=jenkins-image:latest
+
+    # wait for jenkins pod to switch to 'Ready' & 'Running` state:
+    sleep 10
+    echo -e "\n-------------------------------------------------------\n>INFO || Waiting for pod to be ready\n"
+    OUTPUT=$(oc wait pod --for=condition=Ready -l name=jenkins,deploymentconfig=jenkins --timeout=120s)
+
+    if [ -z "${OUTPUT}" ]
+    then
+        exit 1
+    else
+        IFS=" " read -ra ELEMENTS <<< ${OUTPUT}
+        IFS="/" read -r POD POD_NAME <<< ${ELEMENTS[0]}
+    fi
+
+    echo -e "\n-------------------------------------------------------\n>INFO || Pod ${POD_NAME} is available now\n"    
+}
+
+# Creates '/tmp/download_script.sh' script which is executed within the pod.
+# The `download_script.sh` downloads & executes the verify_jenkins.sh inside the pod. 
+# 
+execute_verification_script(){
+
+    # Create a script, that'll execute the `verify-jenkins.sh` within the pod
+    read -e -p "Enter the relevant commit's SHA: " COMMIT_SHA
+    cat > /tmp/download_script.sh << EOL
+curl https://raw.githubusercontent.com/openshift/jenkins/master/scripts/verify-jenkins.sh | SHA=$COMMIT_SHA sh
+EOL
+
+    # Run jenkins verification script inside the pod & redirect the output to a file.
+    echo -e "\n-------------------------------------------------------\n>INFO || Running the verify-jenkins.sh within the pod\n"
+    oc exec -i $POD_NAME -- bash -s < /tmp/download_script.sh &> /tmp/result.out
+
+    # Check if "All tests succeeded" string exists in the file.
+    if [ "$(grep "All tests succeeded" /tmp/result.out)" == "" ]
+    then
+        grep "Jenkins startup" /tmp/result.out -A 3
+        echo -e "\n>>> ERR || Check /tmp/result.out on local machine for details\n"
+        exit 1
+    else
+        echo -e "=== All tests succeeded ==="
+    fi
+}
+
+main(){
+    vars
+    get_image_ready
+    deploy_on_openshift
+    execute_verification_script
+}
+
+main


### PR DESCRIPTION
The script `verify-jenkins-on-openshift.sh` takes the following inputs:
- Cluster's API Server URL
- OpenShift Username & Password
- Jenkins Image
- SHA of the relevant commit (This is requested at a later stage, let me know, if we should input this at the beginning itself (with other variables)).

& Automates the following tasks:
- Pulling the (provided) CPaas image, tagging & pushing it to `quay.io/pipeline-integrations`.
- Logging in to an OpenShift cluster, creating a project & deploying jenkins pod using the provided image.
- Once the pod is ready, executes [verify-jenkins.sh](https://github.com/openshift/jenkins/blob/master/scripts/verify-jenkins.sh) within the pod & redirects the output in a file on local machine.
- Checks for errors in the output file, if found, reports. 