### PR TITLE
Installing Java 17 instead of Java 8

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -49,7 +49,7 @@ EXPOSE 8080 50000
 RUN rm /etc/yum.repos.d/*
 COPY contrib/openshift/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN curl http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel jq xmlstarlet" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-17-openjdk java-17-openjdk-devel jq xmlstarlet" && \
     DISABLES="" && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install epel-release && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install $INSTALL_PKGS && \

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -59,7 +59,7 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-11-openjdk java-11-openjdk-devel java-17-openjdk java-17-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
     yum install -y $INSTALL_PKGS && \
     yum update -y && \
     rpm -V  $INSTALL_PKGS && \


### PR DESCRIPTION
Since Java 8 is no more compatible with Jenkins since version 2.361.1 (see [jenkins docs](https://www.jenkins.io/blog/2022/06/28/require-java-11/)), so there is no more reason to install it in the image. 

Instead, since the same version (see [jenkins docs](https://www.jenkins.io/blog/2023/08/01/documentation-transition-to-java-17/)), Jenkins supports Java 17, so it makes sense to install it in the image so that early adopters can already try it.