### PR TITLE
OCPTOOLS-393: Revert Incomplete Template Update

### DIFF
--- a/openshift/templates/jenkins-ephemeral.json
+++ b/openshift/templates/jenkins-ephemeral.json
@@ -52,8 +52,8 @@
       }
     },
     {
-      "kind": "Deployment",
-      "apiVersion": "apps/v1",
+      "kind": "DeploymentConfig",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${JENKINS_SERVICE_NAME}",
         "annotations": {
@@ -86,14 +86,12 @@
         ],
         "replicas": 1,
         "selector": {
-          "matchLabels": {
-            "app": "${JENKINS_SERVICE_NAME}"
-          }
+          "name": "${JENKINS_SERVICE_NAME}"
         },
         "template": {
           "metadata": {
             "labels": {
-              "app": "${JENKINS_SERVICE_NAME}"
+              "name": "${JENKINS_SERVICE_NAME}"
             }
           },
           "spec": {

--- a/openshift/templates/jenkins-persistent.json
+++ b/openshift/templates/jenkins-persistent.json
@@ -69,8 +69,8 @@
       }
     },
     {
-      "kind": "Deployment",
-      "apiVersion": "apps/v1",
+      "kind": "DeploymentConfig",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${JENKINS_SERVICE_NAME}",
         "annotations": {
@@ -103,14 +103,12 @@
         ],
         "replicas": 1,
         "selector": {
-          "matchLabels": {
-            "app": "${JENKINS_SERVICE_NAME}"
-          }
+          "name": "${JENKINS_SERVICE_NAME}"
         },
         "template": {
           "metadata": {
             "labels": {
-              "app": "${JENKINS_SERVICE_NAME}"
+              "name": "${JENKINS_SERVICE_NAME}"
             }
           },
           "spec": {

--- a/smoke/features/steps/openshift.py
+++ b/smoke/features/steps/openshift.py
@@ -275,18 +275,15 @@ class Openshift(object):
             return output
         return None
 
-    def getmasterpod(self, namespace: str) -> str:
+    def getmasterpod(self, namespace: str)-> str:
         '''
         returns the jenkins master pod name
         '''
-        time.sleep(30)
-        cmd = r'oc get pods --selector="deploymentconfig=jenkins" -o jsonpath --template="{.items[0].metadata.name}" -n ' + namespace
-        print(cmd)
-        output, exit_status = self.cmd.run(cmd)
-        if exit_status == 0:
-            return output
-        return None
-
+        v1 = client.CoreV1Api()
+        pods = v1.list_namespaced_pod(namespace, label_selector='deploymentconfig=jenkins')
+        if len(pods.items) > 1:
+            raise AssertionError
+        return pods.items[0].metadata.name
     
     def scaleReplicas(self, namespace: str, replicas: int, rep_controller: str):
         '''


### PR DESCRIPTION
Reverts openshift/jenkins#1706, which switched the Jenkins templates to use `Deployment` from `DeploymentConfig`. This was an incomplete and left the template with an invalid pod template spec (container image was empty).