### PR TITLE
JKNS-397: Fix USE_JAVA_VERSION environment variable

### DIFF
--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -293,6 +293,16 @@ function container_max_memory_bytes() {
 CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
+export JAVA_VERSION=${USE_JAVA_VERSION:=java-11}
+if [[ "$(uname -m)" == "x86_64" ]]; then
+	alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
+	alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
+#set JVM for all other archs
+else
+  alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
+  alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
+fi
+
 echo "CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"
 
 image_config_dir="/opt/openshift/configuration"

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -44,6 +44,15 @@ function container_max_memory_bytes() {
 CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
+if [[ "$(uname -m)" == "x86_64" ]]; then
+	alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
+	alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
+#set JVM for all other archs
+else
+  alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
+  alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
+fi
+
 echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java)"
 
 shopt -s nocasematch


### PR DESCRIPTION
Fixes #1712

Removed code from #1666 is added back to allow use of other Java versions.