### PR TITLE
JKNS-500: Remove java 11 usage

### DIFF
--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -49,7 +49,7 @@ EXPOSE 8080 50000
 RUN rm /etc/yum.repos.d/*
 COPY contrib/openshift/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN curl http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-17-openjdk java-17-openjdk-devel java-11-openjdk java-11-openjdk-devel jq xmlstarlet" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-17-openjdk java-17-openjdk-devel jq xmlstarlet" && \
     DISABLES="" && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install epel-release && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install $INSTALL_PKGS && \

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -59,7 +59,7 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-17-openjdk java-17-openjdk-devel java-11-openjdk java-11-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-17-openjdk java-17-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
     yum install -y $INSTALL_PKGS && \
     yum update -y && \
     rpm -V  $INSTALL_PKGS && \

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -311,7 +311,6 @@ image_config_path="${image_config_dir}/config.xml"
 if [[ -z "${JAVA_TOOL_OPTIONS}" ]]; then
   # these options will automatically be picked up by any JVM process but can
   # be overridden on that process' command line.
-  # Container support is now integrated in Java 11, the +UseCGroupMemoryLimitForHeap option has been pruned
   JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
   export JAVA_TOOL_OPTIONS
 fi

--- a/BASIC_USAGE.md
+++ b/BASIC_USAGE.md
@@ -34,7 +34,7 @@ initialization by passing `-e VAR=VALUE` to the Docker run command.
 | `AGENT_BASE_IMAGE`	|	Setting this value overrides the image used for the 'jnlp' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'jenkins-agent-base:latest' ImageStreamTag in the 'openshift' namespace is used.	|
 | `JAVA_BUILDER_IMAGE`	|	Setting this value overrides the image used for the 'java-builder' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'java:latest' ImageStreamTag in the 'openshift' namespace is used.	|
 | `NODEJS_BUILDER_IMAGE`	|	Setting this value overrides the image used for the 'nodejs-builder' container in the sample kubernetes plug-in PodTemplates provided with this image.  Otherwise, the image from the 'nodejs:latest' ImageStreamTag in the 'openshift' namespace is used.	|
-| `JAVA_FIPS_OPTIONS`  | Per this [OpenJDK support article](https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk) control how the JVM operates when running on a FIPS node. |
+| `JAVA_FIPS_OPTIONS`  | Per this [OpenJDK support article](https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings) control how the JVM operates when running on a FIPS node. |
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You will need an environment with the following tools installed:
 
 * Maven (the `mvn` command)
 * Git
-* Java 11
+* Java 17
 * an IDE or editor of your choosing
 
 ### Basic code development flow

--- a/openshift/templates/jenkins-ephemeral-monitored.json
+++ b/openshift/templates/jenkins-ephemeral-monitored.json
@@ -355,7 +355,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-ephemeral.json
+++ b/openshift/templates/jenkins-ephemeral.json
@@ -323,7 +323,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-persistent-monitored.json
+++ b/openshift/templates/jenkins-persistent-monitored.json
@@ -383,7 +383,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-persistent.json
+++ b/openshift/templates/jenkins-persistent.json
@@ -351,7 +351,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -22,7 +22,7 @@ USER root
 # Install headless Java
 COPY contrib/openshift/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN curl http://mirror.centos.org/centos-7/7/os/x86_64/RPM-GPG-KEY-CentOS-7 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    INSTALL_PKGS="bc gettext git git-lfs java-17-openjdk-headless java-11-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
+    INSTALL_PKGS="bc gettext git git-lfs java-17-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
     DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
     yum $DISABLES install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager epel-release && \
     yum $DISABLES install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \

--- a/slave-base/Dockerfile.rhel8
+++ b/slave-base/Dockerfile.rhel8
@@ -29,7 +29,7 @@ ENV HOME=/home/jenkins \
 
 USER root
 # Install headless Java
-RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-17-openjdk-headless java-11-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
+RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-17-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
     yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum update -y && \

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -139,7 +139,6 @@ if [[ $(echo "$@" | awk '{print NF}') -gt 1 ]]; then
     fi
   fi
 
-  #NOTE: The following default options are deprecated with java 11. We disable them for all, including java-1.8
   if [[ -z "${JAVA_TOOL_OPTIONS}" ]]; then
     # these options will automatically be picked up by any JVM process but can
     # be overridden on that process' command line.


### PR DESCRIPTION
- Remove java-11-openjdk and java-11-openjdk-headless from Dockerfiles
- Remove java 11 and jdk 11 from comment, doc, s2i and template files

Signed-off-by: Vinu K <kevy.vinu@gmail.com>
(cherry picked from commit f75c532ddc8c69d9bfe88f29bd51ee11692954fb)