### PR TITLE
[JKNS-618]: Update jenkins dnf repo to art-ci

### DIFF
--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -18,7 +18,7 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == false ]]; then
         echo "jenkins.war already exists, skipping upstream RPM installation"
     else
         echo "Installing jenkins.war from upstream RPM"
-        curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo
+        curl https://pkg.jenkins.io/redhat-stable/jenkins.repo -o /etc/yum.repos.art/ci/jenkins.repo
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key


### PR DESCRIPTION
- [x] Update jenkins dnf repo to art-ci

The CI test are failing as dnf repo search location changed to `/etc/yum.repos.art/ci` dir in CI through PR [#5974](https://github.com/openshift-eng/ocp-build-data/pull/5974).