### PR TITLE
 KFLUXMIG-927: Fix rhel8 UBI repository names

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -207,7 +207,7 @@ spec:
           - name: name
             value: buildah-remote-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:b2cfea52e3c007fef50ed8317dfe91ec3cf8379a90efd5858f9a1040dc5a4bbb
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.6@sha256:71074d2bd4ea387c9e22aaec6d27ec508e00b09ffadbea0f1034d4e8cb08c404
           - name: kind
             value: task
         resolver: bundles
@@ -238,7 +238,7 @@ spec:
           - name: name
             value: build-image-index
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:d4c07e29fbd9a7bdcec58b2ad15b656316f935a9009ea387adcb413aa3cd8ecd
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:6978c3abadd6d86010b6fbb376cd6b69356bf6d4415a9a88af2d55e720ffa3ce
           - name: kind
             value: task
         resolver: bundles
@@ -290,7 +290,7 @@ spec:
           - name: name
             value: deprecated-image-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:462baed733dfc38aca5395499e92f19b6f13a74c2e88fe5d86c3cffa2f899b57
           - name: kind
             value: task
         resolver: bundles
@@ -368,7 +368,7 @@ spec:
           - name: name
             value: sast-snyk-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:60f2dac41844d222086ff7f477e51f3563716b183d87db89f603d6f604c21760
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:8ad28b7783837a24acbc9a8494c935e796e591ce476085ad5899bebd7e53f077
           - name: kind
             value: task
         resolver: bundles
@@ -440,7 +440,7 @@ spec:
           - name: name
             value: sast-coverity-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ae62d14c999fd93246fef4e57d28570fa5200c3266b9a3263a39965e5a5b02d7
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:78f5244a8cfd28c890ed62db7e4ff1fc97ff39876d37fb19f1b0c2c286a4002c
           - name: kind
             value: task
         resolver: bundles
@@ -461,7 +461,7 @@ spec:
           - name: name
             value: coverity-availability-check
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:5623e48314ffd583e9cab383011dc0763b6c92b09c4f427b8bfcca885394a21c
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:36400873d3031df128c55aa71ee11d322c3e55fd8f13dc5779098fbc117c0aa3
           - name: kind
             value: task
         resolver: bundles
@@ -487,7 +487,7 @@ spec:
           - name: name
             value: sast-shell-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1f0fcba24ebc447d9f8a2ea2e8f262fa435d6c523ca6b0346cd67261551fc9ed
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:d44336d7bcbd1f7cedee639357a493bd1f661e2859e49e11a34644bdf6819c4e
           - name: kind
             value: task
         resolver: bundles
@@ -513,7 +513,7 @@ spec:
           - name: name
             value: sast-unicode-check-oci-ta
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:1833c618170ab9deb8455667f220df8e88d16ccd630a2361366f594e2bdcb712
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:e5a8d3e8e7be7246a1460385b95c084ea6e8fe7520d40fe4389deb90f1bf5176
           - name: kind
             value: task
         resolver: bundles
@@ -535,7 +535,7 @@ spec:
           - name: name
             value: apply-tags
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:f44be1bf0262471f2f503f5e19da5f0628dcaf968c86272a2ad6b4871e708448
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:55fc1eded400e29ff47eccd212ca42461c7e614b8ce3448d6482f9ae84b0e6cd
           - name: kind
             value: task
         resolver: bundles
@@ -575,7 +575,7 @@ spec:
           - name: name
             value: rpms-signature-scan
           - name: bundle
-            value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:3d016c63bcab64ab82da762a52b013c0bcb534e9523b8c0e073cc3a0c02f0cac
+            value: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:9c3a523814410046412abc09beb6f10082fecc56eb6d3386f6a6df305e5e011e
           - name: kind
             value: task
         resolver: bundles

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -5,1092 +5,1092 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 159316
     checksum: sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c
     name: abattis-cantarell-fonts
     evr: 0.0.25-6.el8
     sourcerpm: abattis-cantarell-fonts-0.0.25-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/adwaita-cursor-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 662496
     checksum: sha256:1672a332f0108712757853e99e63fc9f659fe14cfc3d36b6e36ce07c564ef05a
     name: adwaita-cursor-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/adwaita-icon-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 11982852
     checksum: sha256:99cf2d2181327417b07c83fd999749774046330f5ca24991d3eb4d967aed6bae
     name: adwaita-icon-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/alsa-lib-1.2.10-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 481152
     checksum: sha256:a64e96e6f3b423d15262904d14656b793c5981481a6c8f129b7d00c8c4a45b05
     name: alsa-lib
     evr: 1.2.10-2.el8
     sourcerpm: alsa-lib-1.2.10-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/at-spi2-atk-2.26.2-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 88676
     checksum: sha256:612d6addc2c05d041098ea6e618dabd967dcf9d39629f0676d78c9bb1387d1a6
     name: at-spi2-atk
     evr: 2.26.2-1.el8
     sourcerpm: at-spi2-atk-2.26.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/at-spi2-core-2.28.0-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 168824
     checksum: sha256:1ae37519ad62c7baf117ab69a9e81ab3161fe96e738abcd9b0aca44987c3adcd
     name: at-spi2-core
     evr: 2.28.0-1.el8
     sourcerpm: at-spi2-core-2.28.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/a/atk-2.28.1-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 276580
     checksum: sha256:4c6e73e5bd431961f2e12260c540c56bd30824d97d2befb865f4e8166507b3e5
     name: atk
     evr: 2.28.1-1.el8
     sourcerpm: atk-2.28.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/c/cairo-1.15.12-6.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 688624
     checksum: sha256:fef2470606a077adae6f6e9d1b3c64764c4224f89d7948403c6096fe38b54bc7
     name: cairo
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/c/cairo-gobject-1.15.12-6.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 33816
     checksum: sha256:b52146b375f8507f7a56b8b90754b820e2a20fac4437f7e71b7d1c5db5c27298
     name: cairo-gobject
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/c/colord-libs-1.4.2-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 223660
     checksum: sha256:d408576d2222f7e0b7ebb062af743ffc712ed73b226b76ce4ab32d6f463ee69e
     name: colord-libs
     evr: 1.4.2-1.el8
     sourcerpm: colord-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/c/copy-jdk-configs-4.0-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 31276
     checksum: sha256:5520be18012994682dd26352095e9ddea7d63e95c557cb411048a721cd6322c8
     name: copy-jdk-configs
     evr: 4.0-2.el8
     sourcerpm: copy-jdk-configs-4.0-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/d/dconf-0.28.0-4.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 107852
     checksum: sha256:aa619a5abfc4169938fe816795f6ce4d4252f690c01af582dc893549feb6b5e7
     name: dconf
     evr: 0.28.0-4.el8
     sourcerpm: dconf-0.28.0-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/f/fribidi-1.0.4-9.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 90740
     checksum: sha256:c6182b7978e1b94dbef1281516cf627a6eff88da3623afbd53ab9347d13d3101
     name: fribidi
     evr: 1.0.4-9.el8
     sourcerpm: fribidi-1.0.4-9.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.36.12-7.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 107212
     checksum: sha256:2f8f183c2f74f8b227711537513006b265dceb21af97a497c320aea4c9add04e
     name: gdk-pixbuf2-modules
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/git-2.43.7-1.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 94860
     checksum: sha256:360e8689c9a9f5c286b4428a3c46f7017eea21751a9499ae168462a41e1e17a0
     name: git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/git-core-2.43.7-1.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 11216788
     checksum: sha256:d23f02a074c97383eda8f833f8a3f1916b4b1c55ba5149d0cbfd4ee69254d471
     name: git-core
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/git-core-doc-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 3216756
     checksum: sha256:09202aba03724180992d4cb6a3c617423ee25dc61f2c162990a25d7781977058
     name: git-core-doc
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/git-lfs-3.4.1-5.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 4150776
     checksum: sha256:bda13be68230af48e46ce3e5ed606aa2d14640846dc1869564a865c821d8b3d8
     name: git-lfs
     evr: 3.4.1-5.el8_10
     sourcerpm: git-lfs-3.4.1-5.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/graphite2-1.3.10-10.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 115744
     checksum: sha256:d6a4888b6246ef1d22c0a53277d17574c55fa886255f6e447dec4e4ae81232c8
     name: graphite2
     evr: 1.3.10-10.el8
     sourcerpm: graphite2-1.3.10-10.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/gtk-update-icon-cache-3.22.30-12.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 32680
     checksum: sha256:1c886e4045811a2acce5d4c6155e7ba68f2355f7a8adde91e91d87464120ea3d
     name: gtk-update-icon-cache
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/g/gtk3-3.22.30-12.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 4527532
     checksum: sha256:43d7c168d4ee9d955604d5d072180e4d6d57fcf16e678efbb2618deb97d1bc11
     name: gtk3
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/h/harfbuzz-1.7.5-4.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 286844
     checksum: sha256:439e04fee7ad92c917adae9c2720eb0ece1948b625ae6b2c67627413cbd76447
     name: harfbuzz
     evr: 1.7.5-4.el8
     sourcerpm: harfbuzz-1.7.5-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/h/hicolor-icon-theme-0.17-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 49600
     checksum: sha256:66bab4d22c2d9f29dc7c7651afa44456e306c6c9c175f96f5021b1887d9a5796
     name: hicolor-icon-theme
     evr: 0.17-2.el8
     sourcerpm: hicolor-icon-theme-0.17-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/jasper-libs-2.0.14-6.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 161868
     checksum: sha256:80e45574b3f5438df7e7b1d4aa04c51cee40ae09f4cf8fddcdb88120390186b7
     name: jasper-libs
     evr: 2.0.14-6.el8_10
     sourcerpm: jasper-2.0.14-6.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-17.0.16.0.8-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 486452
-    checksum: sha256:c93e4d020312d5aea2aa48a5157f23bdbdc72ad8f66149f0d3dcb3bf00da4f66
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 492448
+    checksum: sha256:474628162d4d49fbd02dc22302dfead347ff988673e1f28b625e9e096a3e5c59
     name: java-17-openjdk
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-devel-17.0.16.0.8-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 5371520
-    checksum: sha256:d37420aed9e0a2bfcb9b4741adb6148e2ac4055dcf2f1dda4bd6bdb08f2d8517
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-devel-17.0.17.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 5371220
+    checksum: sha256:db7ffabc04c5328f57747e9f80385457faa9a1b5393cc51951999e310e07fe51
     name: java-17-openjdk-devel
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.16.0.8-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 47634868
-    checksum: sha256:84274e7bfb63e2667a85169b5d77fd2cb07ce42199015e3954017c11fddf226f
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 47685828
+    checksum: sha256:6ae5908d3b69bcd38480a33073a0cc9d7d7e1bda86bbfed632eac9e0873a7c9a
     name: java-17-openjdk-headless
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-21.0.8.0.9-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 404428
-    checksum: sha256:7bd44c2b8f209483355af94c9bc873891358c0dd8ee9b0ac9e2b615a6f68dc6e
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-21.0.9.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 385732
+    checksum: sha256:832d00b1c3d63798eb23dc538f75f273c81037c5a393395d8cf78d82402101c5
     name: java-21-openjdk
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-devel-21.0.8.0.9-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 5418568
-    checksum: sha256:6c918d230dd6eeeda8e9eb5b975a37ef86af4dd846c2a8fae83b21d03c4c311b
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-devel-21.0.9.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 5417920
+    checksum: sha256:8fb6e9ae087d79e7d65a208ed077f44fd5a86492b1ba7012c5f895cd7d030889
     name: java-21-openjdk-devel
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-headless-21.0.8.0.9-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 51492356
-    checksum: sha256:9608b35b2c9d688498e0dbaf68a1123857acbcb1ed9b7d12c2b15b106c615d11
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/java-21-openjdk-headless-21.0.9.0.10-1.el8.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 51539108
+    checksum: sha256:b9e36399ef971d348ace07a1a0d8ba73785f0aa4c1d0c95325c1831eb3f4ffb7
     name: java-21-openjdk-headless
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 31089
     checksum: sha256:0a2665447c6c2559229438b3cbb9b2a9c8d54886fc5cc9801d823d9991386a55
     name: javapackages-filesystem
     evr: 5.3.0-1.module+el8+2447+6f56d9a6
     sourcerpm: javapackages-tools-5.3.0-1.module+el8+2447+6f56d9a6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/jbigkit-libs-2.1-14.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 54932
     checksum: sha256:41587e7a2b01de95dd50aef323c98c7264f84016e99fde1454041d4bacbfc2b9
     name: jbigkit-libs
     evr: 2.1-14.el8
     sourcerpm: jbigkit-2.1-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/j/jq-1.6-11.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 194428
     checksum: sha256:18872c00a1f4d6661bd4eec1240e21ae85b1bfa81fc12a3da3c0d4f663344648
     name: jq
     evr: 1.6-11.el8_10
     sourcerpm: jq-1.6-11.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/lcms2-2.9-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 160140
     checksum: sha256:e26b15f1f0ab31958a0ce7b5b5c1abda9706854ff8281c014780c1540fa2f46f
     name: lcms2
     evr: 2.9-2.el8
     sourcerpm: lcms2-2.9-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libX11-1.6.8-9.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 603676
     checksum: sha256:8009b5a72e1cf1a93cb3de6b4684687d4f9f3ed9860c632693dc7ce6c684a343
     name: libX11
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libX11-common-1.6.8-9.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 162348
     checksum: sha256:558399ee08f1281a9e2eff4c0bbc3756d374d0e543587bcf2c12e557df479cc6
     name: libX11-common
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXau-1.0.9-3.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 38316
     checksum: sha256:5176881bae429bec5136195c73b402081184ae2a35519673031a075e855f75f4
     name: libXau
     evr: 1.0.9-3.el8
     sourcerpm: libXau-1.0.9-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXcomposite-0.4.4-14.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 29264
     checksum: sha256:70bf6f5fd99a82861577f2d1223b53f9d1d0a8a34448559616b1dba9427f756e
     name: libXcomposite
     evr: 0.4.4-14.el8
     sourcerpm: libXcomposite-0.4.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXcursor-1.1.15-3.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 36192
     checksum: sha256:1262d5e51ce5e90c5e1010489f1cad2c634690367ed4bd2a6a137ba72e5e0d6c
     name: libXcursor
     evr: 1.1.15-3.el8
     sourcerpm: libXcursor-1.1.15-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXdamage-1.1.4-14.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 27400
     checksum: sha256:ec98634d6e8a9abfcb04cacbff4b4ee7e9c1e8aee98c538648235d0c3412c355
     name: libXdamage
     evr: 1.1.4-14.el8
     sourcerpm: libXdamage-1.1.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXext-1.3.4-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 44996
     checksum: sha256:740e25055db923edcb8a0bddebc688de61a17c6b738162163e9b569e0cda1e18
     name: libXext
     evr: 1.3.4-1.el8
     sourcerpm: libXext-1.3.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXfixes-5.0.3-7.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 25272
     checksum: sha256:cbf25aa7faf9114e9735dbc120fb8fdda1694c86ab24c204383faf484720ee58
     name: libXfixes
     evr: 5.0.3-7.el8
     sourcerpm: libXfixes-5.0.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXft-2.3.3-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 66108
     checksum: sha256:553e1debae8bfd65f919cbe10bfda63f552e38ee9b0a26b18ae6da26f35fe248
     name: libXft
     evr: 2.3.3-1.el8
     sourcerpm: libXft-2.3.3-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXi-1.7.10-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 47396
     checksum: sha256:e3afaa074aa7ce98d19dbbcabec83f0d3f6a56225c49ea149b355783ea35809d
     name: libXi
     evr: 1.7.10-1.el8
     sourcerpm: libXi-1.7.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXinerama-1.1.4-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 15860
     checksum: sha256:2a9a97f4ff381c061f075608ef3b1fed18ce11a07acd84a74160540e426f1723
     name: libXinerama
     evr: 1.1.4-1.el8
     sourcerpm: libXinerama-1.1.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXrandr-1.5.2-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 33476
     checksum: sha256:af3adfdba9b6ca2e6e8a57d60b64e11994bb6dbdcd63d03492c29c763b8f22c2
     name: libXrandr
     evr: 1.5.2-1.el8
     sourcerpm: libXrandr-1.5.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXrender-0.9.10-7.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 32136
     checksum: sha256:92bc3c29b5232c55f60c9d0a5426bb04675209b8ee87df5725a83a60944219cb
     name: libXrender
     evr: 0.9.10-7.el8
     sourcerpm: libXrender-0.9.10-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libXtst-1.2.3-7.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 22060
     checksum: sha256:29c21e66c32e5205762dcda5d372ae222e16087238d6148eddb7d5e735de9910
     name: libXtst
     evr: 1.2.3-7.el8
     sourcerpm: libXtst-1.2.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libdatrie-0.2.9-7.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 33308
     checksum: sha256:d375554ad9c48e02717d322fa9f549d7817ca6955db91bda9b861cc498e569b6
     name: libdatrie
     evr: 0.2.9-7.el8
     sourcerpm: libdatrie-0.2.9-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libepoxy-1.5.8-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 238388
     checksum: sha256:9aab148634e9abe5d2fcad1b6fe865d3b81ca977e47b76c2d72827183fdd57de
     name: libepoxy
     evr: 1.5.8-1.el8
     sourcerpm: libepoxy-1.5.8-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libfontenc-1.1.3-8.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 37376
     checksum: sha256:8222a5f9af57bcb2778b1717b233ca8c87c60615f3b9e56af43e0f41a32d5f19
     name: libfontenc
     evr: 1.1.3-8.el8
     sourcerpm: libfontenc-1.1.3-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libjpeg-turbo-1.5.3-14.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 150144
     checksum: sha256:947aa1cf4323293b201baf5eb1907d5e55676d1b4238df24dfbce0d500c9f632
     name: libjpeg-turbo
     evr: 1.5.3-14.el8_10
     sourcerpm: libjpeg-turbo-1.5.3-14.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libthai-0.1.27-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 206300
     checksum: sha256:098dcdd284028800b67a6a813aa0ec4282cd77c3aeb4b11b2deaac4c587a8ce5
     name: libthai
     evr: 0.1.27-2.el8
     sourcerpm: libthai-0.1.27-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libtiff-4.0.9-34.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
-    size: 184980
-    checksum: sha256:49eca17f6107f74d152e85e86c3433d1311bc2e5aae60d077c43de96afc20ea1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libtiff-4.0.9-35.el8_10.aarch64.rpm
+    repoid: ubi-8-for-aarch64-appstream-rpms
+    size: 184060
+    checksum: sha256:231a3ad79e880bd39478d85121cb009ed34ec91083ce697794c35673cc0635ca
     name: libtiff
-    evr: 4.0.9-34.el8_10
-    sourcerpm: libtiff-4.0.9-34.el8_10.src.rpm
+    evr: 4.0.9-35.el8_10
+    sourcerpm: libtiff-4.0.9-35.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libwayland-client-1.21.0-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 40692
     checksum: sha256:745a5bde50d42e72d9699552bbe82175dae35c414dd8e389bac252ac80936d53
     name: libwayland-client
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libwayland-cursor-1.21.0-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 26032
     checksum: sha256:981a302689cdfccbe48a02a791ba09e699cabedda648a6104ea2054bb52831ef
     name: libwayland-cursor
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libwayland-egl-1.21.0-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 20016
     checksum: sha256:060557ff524871bae1b6d7139c888dfd78823ed0ab5e994fabde3b2e8f350fc6
     name: libwayland-egl
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/libxcb-1.13.1-1.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 227948
     checksum: sha256:3e570377bfb3946bbbbe32abfc92f800af7922d0a448e3f044ef75b18e97b924
     name: libxcb
     evr: 1.13.1-1.el8
     sourcerpm: libxcb-1.13.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/l/lua-5.3.4-12.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 192820
     checksum: sha256:48308b9b6069a22224ca018dc096436da987b13ccec1a3962e0c24b7b713425e
     name: lua
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nspr-4.36.0-2.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 139688
     checksum: sha256:5ea3ca916a7ab2e4a75e86fce5297c654ade928c9006fc5831da40609a71f6fa
     name: nspr
     evr: 4.36.0-2.el8_10
     sourcerpm: nspr-4.36.0-2.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nss-3.112.0-4.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 745620
     checksum: sha256:b2a2becc67bd7ec0aa47fcb79ceaaa8df2eeedecc4f6074915a403f07732242f
     name: nss
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 535768
     checksum: sha256:660bc818c6f72d01b400cef00a4ce2a9139a059e859b70d72fe635a3de96d8a0
     name: nss-softokn
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 454956
     checksum: sha256:d721616e27b76ffd12255423f7620d6aa43b841b348d1e6a0eba6be91f361f62
     name: nss-softokn-freebl
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 77844
     checksum: sha256:9ef11caa804c7542c4f593b92eed91f48f6d648655e934681d6e828d59513989
     name: nss-sysinit
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/n/nss-util-3.112.0-4.el8_10.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 142364
     checksum: sha256:3251d407aa42d0229993c08793462727d5bdaf9139cc9b595a435e2fe160f085
     name: nss-util
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 185652
     checksum: sha256:ef5cbd14f7e46e55b6a8f51b5060b15170110a5c4cfa3042f22e4835a1634aa6
     name: oniguruma
     evr: 6.8.2-3.el8
     sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/pango-1.42.4-8.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 292248
     checksum: sha256:a370f6885e353ab6edb99c38437dc3a8261b4639bb24c1e3c5ae2b829478dd6c
     name: pango
     evr: 1.42.4-8.el8
     sourcerpm: pango-1.42.4-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Digest-MD5-2.55-396.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 38052
     checksum: sha256:b5774cc6cf397117a0a9a5f7aad450385a2583bc055ee3aaf203e8e66660a5ca
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Git-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 81136
     checksum: sha256:cc2b622933dabf0579711ce3fdccfd5b485483b8b0f8ed4dc2df3d59842ba735
     name: perl-Git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 382078
     checksum: sha256:5fa7d59d88f7fba04bbfb2321873611819be05ff26d29a407fc60d955946721c
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 40824
     checksum: sha256:0730f7dbf64d2b608716d14affb23beedbc7449d01901331439b61acf606004a
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/p/pixman-0.38.4-4.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 152912
     checksum: sha256:b135bad6a032fb4259b2ec2bd7baaf2f904915320e8bb244d662885b24e247b6
     name: pixman
     evr: 0.38.4-4.el8
     sourcerpm: pixman-0.38.4-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/r/rest-0.8.1-2.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 69892
     checksum: sha256:7c4edc91b4325cbcfe881eb91fbbbd6fbd6ac5c9b3cb71b4035facb566c5bd2e
     name: rest
     evr: 0.8.1-2.el8
     sourcerpm: rest-0.8.1-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/t/ttmkfdir-3.0.9-54.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 59504
     checksum: sha256:6424c906bb192aa950f3e583bb88d4d7c9e84cb8f750b29e7ff7e02eae2d1b8d
     name: ttmkfdir
     evr: 3.0.9-54.el8
     sourcerpm: ttmkfdir-3.0.9-54.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/t/tzdata-java-2025b-1.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 191116
     checksum: sha256:3fa146aae879f61ff54642ba5b8b2922ef49b09c2a931ad4314b4137fd884175
     name: tzdata-java
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/x/xmlstarlet-1.6.1-20.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 70808
     checksum: sha256:3ace14d5ecc1c977408a505311a81e91e92072ccf10c93b151f5f9ac7ca50233
     name: xmlstarlet
     evr: 1.6.1-20.el8
     sourcerpm: xmlstarlet-1.6.1-20.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/x/xorg-x11-font-utils-7.5-41.el8.aarch64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 102760
     checksum: sha256:c3b4faa7caa13d24dd488e4500a2596922ffa52743e597c05c00a246e646ea99
     name: xorg-x11-font-utils
     evr: 1:7.5-41.el8
     sourcerpm: xorg-x11-font-utils-7.5-41.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/Packages/x/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 534388
     checksum: sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae
     name: xorg-x11-fonts-Type1
     evr: 7.5-19.el8
     sourcerpm: xorg-x11-fonts-7.5-19.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/a/avahi-libs-0.7-27.el8_10.1.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 62280
     checksum: sha256:f9c1ca6bf6a046ed41ffbfdba8d45d6ffe0f260c579f579cf7852565d81a8c6d
     name: avahi-libs
     evr: 0.7-27.el8_10.1
     sourcerpm: avahi-0.7-27.el8_10.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/b/bc-1.07.1-5.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 130016
     checksum: sha256:bc70a79293d4501bd3ff1ff74210058b5795dfb2c10a0e8f29fdabdff1182c57
     name: bc
     evr: 1.07.1-5.el8
     sourcerpm: bc-1.07.1-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/b/bzip2-1.0.6-28.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 61404
     checksum: sha256:3326455c7b98ea42265424a283914b509d2ab0cf45ed0c2a86e873458322b6bd
     name: bzip2
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/c/cups-libs-2.2.6-63.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 430940
     checksum: sha256:7df0ef7b0537b32867ded48ddf8908c5632183cdd328064bd4a65f954651fd3a
     name: cups-libs
     evr: 1:2.2.6-63.el8_10
     sourcerpm: cups-2.2.6-63.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/d/dejavu-fonts-common-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 76096
     checksum: sha256:82f36244bf29111473619a3565e69d3e8213e829d8eaf3e141c6c397d574ccf3
     name: dejavu-fonts-common
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/d/dejavu-sans-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 1558464
     checksum: sha256:488d2b14e88a91dfe40d5dbf9136f29b155d1fe22f6a6c442db528684cb55e95
     name: dejavu-sans-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/d/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 457788
     checksum: sha256:bb4b2ae2789e9295d835c3c48705f5bd7f6813613f91faab19d4bcb37300b1c2
     name: dejavu-sans-mono-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/e/emacs-filesystem-26.1-15.el8_10.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 72500
     checksum: sha256:3752a72be8d33b701a01e746dc2f8d56e2ba7829baa5f2bf3f1a590d8267c60a
     name: emacs-filesystem
     evr: 1:26.1-15.el8_10
     sourcerpm: emacs-26.1-15.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/f/fontconfig-2.13.1-4.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 278936
     checksum: sha256:ddc52b6052ac2415f54ee53b590ede61944cacd112f87117865459640bf46582
     name: fontconfig
     evr: 2.13.1-4.el8
     sourcerpm: fontconfig-2.13.1-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/f/fontpackages-filesystem-1.44-22.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 16324
     checksum: sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0
     name: fontpackages-filesystem
     evr: 1.44-22.el8
     sourcerpm: fontpackages-1.44-22.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/f/freetype-2.9.1-10.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 378960
     checksum: sha256:c613950a2b585bf2bce69eeb92dcd047e32c9bb9fca7bfe19919794f5898c73a
     name: freetype
     evr: 2.9.1-10.el8_10
     sourcerpm: freetype-2.9.1-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/gdk-pixbuf2-2.36.12-7.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 472900
     checksum: sha256:9e43cd80c175f34599f672cf45b64126e071443cdd0577523bd0366b3633004d
     name: gdk-pixbuf2
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 1102240
     checksum: sha256:fddf61e9024c41073442ccff0c9990fa004e9b183f391c4e3cf3853e5ae6062c
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 302820
     checksum: sha256:ce6960fa7831611815e163864a91b70b0ab1ef0f446c2cad1eec13404822cad5
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/glib-networking-2.56.1-1.1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 155564
     checksum: sha256:6b1dcf4c02ee8c588c0ae44af92ae1060dcdc44f197e624a71fb31c86554ad2c
     name: glib-networking
     evr: 2.56.1-1.1.el8
     sourcerpm: glib-networking-2.56.1-1.1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/glibc-locale-source-2.28-251.el8_10.25.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 4418704
     checksum: sha256:1fb16e828bfaaf6c72684e1bfd44440a8514f105416ffd86e4d757914f9da428
     name: glibc-locale-source
     evr: 2.28-251.el8_10.25
     sourcerpm: glibc-2.28-251.el8_10.25.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/groff-base-1.22.3-18.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 1018336
     checksum: sha256:8f2c073583d6d4347642139a9806174ba64848c6bd4fbc81b7e7e0d42751cc74
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/g/gsettings-desktop-schemas-3.32.0-6.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 648024
     checksum: sha256:ba0daa8307b287a4e92af9c5aff1e6abc828de0e53f91003e3346c9352220eee
     name: gsettings-desktop-schemas
     evr: 3.32.0-6.el8
     sourcerpm: gsettings-desktop-schemas-3.32.0-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/less-530-3.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 165440
     checksum: sha256:3f397089911c4696d0f009ad7849680ade390341015139d07b2af8ae5265d05c
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 110936
     checksum: sha256:e58ae3f8143d7fe7247aa9ae03bf0df30e7877e61dbebe727f4b4ff67f2e7395
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 101124
     checksum: sha256:b93a509fc65dd88761b4f7f21d8a05f1cd22e878ac59eb7d8e1507f5a2376a1e
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libgomp-8.5.0-28.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 205940
     checksum: sha256:512bbfdb1fbd85a541ce5e189979268245eded10ed6e9ec67fd4d19e28d79541
     name: libgomp
     evr: 8.5.0-28.el8_10
     sourcerpm: gcc-8.5.0-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libgusb-0.3.0-1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 48928
     checksum: sha256:89bd26efe94889e657c5cedede8b5eede7d4e8833619218753df6ab5ab477d37
     name: libgusb
     evr: 0.3.0-1.el8
     sourcerpm: libgusb-0.3.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libmodman-2.0.1-17.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 35848
     checksum: sha256:9fdfb9c1ced62828bfcb186bb83caf470b4c14a53611c0ab7f08035333b6dbee
     name: libmodman
     evr: 2.0.1-17.el8
     sourcerpm: libmodman-2.0.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 34540
     checksum: sha256:a006b695c5a4c6caff337a60a2a6b89a12f0dedb4e2fe47b9f1e68d2a838508f
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libpng-1.6.34-5.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 121996
     checksum: sha256:1fbb9fed42dff3f9dbc9e4fd929281408f77506423424759c2ac57b76afc3cdb
     name: libpng
     evr: 2:1.6.34-5.el8
     sourcerpm: libpng-1.6.34-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libproxy-0.4.15-5.5.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 70808
     checksum: sha256:8cc2e5d2430e92eb52449c0dc9ec1bf1a9f3d6c709a3288efbf197639f48786b
     name: libproxy
     evr: 0.4.15-5.5.el8_10
     sourcerpm: libproxy-0.4.15-5.5.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libsoup-2.62.3-9.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
-    size: 419952
-    checksum: sha256:a25ec3ad717e1eaac87a4e45ddfaf6972cd5b930dbd24f5a3c8da79ec0e3a9fd
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libsoup-2.62.3-10.el8_10.aarch64.rpm
+    repoid: ubi-8-for-aarch64-baseos-rpms
+    size: 418776
+    checksum: sha256:54bde1348536f04d9acb96f80d58443a71f27c461198d74239bd1bf70cb8d6df
     name: libsoup
-    evr: 2.62.3-9.el8_10
-    sourcerpm: libsoup-2.62.3-9.el8_10.src.rpm
+    evr: 2.62.3-10.el8_10
+    sourcerpm: libsoup-2.62.3-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/libxslt-1.1.32-6.3.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 244924
     checksum: sha256:ee6e05d045782a16a4df94707317db37bb2d57e0b46f12e222d7e523de252e13
     name: libxslt
     evr: 1.1.32-6.3.el8_10
     sourcerpm: libxslt-1.1.32-6.3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/l/lksctp-tools-1.0.18-3.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 100312
     checksum: sha256:625d84739340fcadb919ae266529b69b126bb025d28d21f03d3ff47c8e5983bc
     name: lksctp-tools
     evr: 1.0.18-3.el8
     sourcerpm: lksctp-tools-1.0.18-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 392540
     checksum: sha256:f2a74fd05139d667fb66fada5dff92bff1abfbe3986eb51985eae5b1c27ed256
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/o/openssh-8.0p1-26.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 502032
     checksum: sha256:62218045aa14e11e9a20658bf1544532e5376409e6e59a0e80456bac66e7e51e
     name: openssh
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/o/openssh-clients-8.0p1-26.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 642908
     checksum: sha256:c58de07e793ac839d3dced06b08192834af7c64623736db2abbf1f62e287f25c
     name: openssh-clients
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 57964
     checksum: sha256:32f4dded60a9508a61cd115e90afeeb026698afb7d1cb095b12c1b075d368c5b
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Encode-2.97-3.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 1529800
     checksum: sha256:3155de184effa74f0e04882f0dfb7a5c76e746a22747805d86aff5aaad235ec8
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Errno-1.28-423.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 78544
     checksum: sha256:15c4ab8fca38fe06e463927af8936ed755e7994ee3f286f50e63f5a428701163
     name: perl-Errno
     evr: 1.28-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-IO-1.38-423.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 145836
     checksum: sha256:60bd454ea141b73759aedca4836fc6359757aa9984097fd6bb4e361944ac765b
     name: perl-IO
     evr: 1.38-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 31380
     checksum: sha256:a1d320b27056062b54ff814b2db9e2c482c895c24c7228abfac607c36fee55cc
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 92068
     checksum: sha256:f7ac39e3e7688439f48cd48404d3f81c0e210002241b353afa497cfc92d6731b
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 68188
     checksum: sha256:2743dfcdabfebab5eaa0732c71f9af7955f0fa2c59ac4d91ab4e3f0bf3926a40
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Socket-2.027-3.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 60072
     checksum: sha256:8543ffa01fedadd46ed9394074576b71d3be4d7b77f39ba01f8e76f04a4dc03f
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Storable-3.11-3.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 96932
     checksum: sha256:419ff71613ae759c9a05c82570417eec82d3b3d5d968bce1132b5a205722dc5f
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 80328
     checksum: sha256:e235a5cb53890a37348177124747a058e8affcd49bee72f66a2bca20fe126481
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-interpreter-5.26.3-423.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 6614856
     checksum: sha256:28ed32c7428a2eb0d0d84f36428b260c193fbe7bdc0e5efc09333235704b1a58
     name: perl-interpreter
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-libs-5.26.3-423.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 1536308
     checksum: sha256:71a603b90fc7b08d8ff4696840eb78f2cfae6b023c7546bf8d1407b9bba7ee5a
     name: perl-libs
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-macros-5.26.3-423.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 74452
     checksum: sha256:658b34b93f6fc5fd7f5ae43c5f6f14684b2bab74416dac0277d6f79f56791b8d
     name: perl-macros
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-threads-2.21-2.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 61536
     checksum: sha256:a559858e5c3608f1fe5710723bb4e06ed8607d734847acdcd73f8e37f2b06d2f
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 48104
     checksum: sha256:ee194fd7853f86a3ab1cc40d8faa1b36458a68502cd5cfe4fae5181aa13c2aba
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 38244
     checksum: sha256:1d39ffccb1971cf4c3b6d6e6c6415c9fceb50238f312ab9fa2417bce03679785
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 15604
     checksum: sha256:421dd99d6a2654b08f01d62c1921116f80d6799eb99ff58c45ac055b3d7f731a
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/u/unzip-6.0-48.el8_10.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 194372
     checksum: sha256:fc222e01a39a9ddfadb8aec667e866e0bcb584573fc376d3a1b9144d0f025bec
     name: unzip
     evr: 6.0-48.el8_10
     sourcerpm: unzip-6.0-48.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/baseos/os/Packages/z/zip-3.0-23.el8.aarch64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-aarch64-baseos-rpms
     size: 271168
     checksum: sha256:1cd00e05ba5db89059a1cce3808cd39a7cf1b04d3337f3b99d986a5b6f7f74c7
     name: zip
@@ -1098,1099 +1098,1099 @@ arches:
     sourcerpm: zip-3.0-23.el8.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/repodata/1a4a53275524e639ea9b464058d2947311ed47789b3f52f31564cff12dd2fabd-modules.yaml.gz
-    repoid: ubi-8-appstream
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/aarch64/appstream/os/repodata/257c202272132b7653e56f6d239080435e7d90af536cabeb354015c10ce30ecd-modules.yaml.gz
+    repoid: ubi-8-for-aarch64-appstream-rpms
     size: 57035
-    checksum: sha256:1a4a53275524e639ea9b464058d2947311ed47789b3f52f31564cff12dd2fabd
+    checksum: sha256:257c202272132b7653e56f6d239080435e7d90af536cabeb354015c10ce30ecd
 - arch: ppc64le
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 159316
     checksum: sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c
     name: abattis-cantarell-fonts
     evr: 0.0.25-6.el8
     sourcerpm: abattis-cantarell-fonts-0.0.25-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/adwaita-cursor-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 662496
     checksum: sha256:1672a332f0108712757853e99e63fc9f659fe14cfc3d36b6e36ce07c564ef05a
     name: adwaita-cursor-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/adwaita-icon-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 11982852
     checksum: sha256:99cf2d2181327417b07c83fd999749774046330f5ca24991d3eb4d967aed6bae
     name: adwaita-icon-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/alsa-lib-1.2.10-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 572680
     checksum: sha256:4d063fc585d44c589a338192b9b7527b36f5482c0eed1250d74fa6732cf79b0b
     name: alsa-lib
     evr: 1.2.10-2.el8
     sourcerpm: alsa-lib-1.2.10-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/at-spi2-atk-2.26.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 98900
     checksum: sha256:68982c7f36c9f8d7846ba631ad91d92ebb47c6eccc5ac67c82c85746b2860b02
     name: at-spi2-atk
     evr: 2.26.2-1.el8
     sourcerpm: at-spi2-atk-2.26.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/at-spi2-core-2.28.0-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 188800
     checksum: sha256:e62258fcdef8414d96615f1b511e23833e09d254c3eebd209ef0b002cbcd01d7
     name: at-spi2-core
     evr: 2.28.0-1.el8
     sourcerpm: at-spi2-core-2.28.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/a/atk-2.28.1-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 281576
     checksum: sha256:46cfb9329f359fc04ef0453f2cb87e098baa084f2d88390e1abcb26998df383c
     name: atk
     evr: 2.28.1-1.el8
     sourcerpm: atk-2.28.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/c/cairo-1.15.12-6.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 793892
     checksum: sha256:4601bf2f705d08c75cf83f6a0db51d5c4f6e31537e114a68161b907405fe6278
     name: cairo
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/c/cairo-gobject-1.15.12-6.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 34320
     checksum: sha256:b766b637d4aa4222db343cdc582071c03d9a5d804bb8e634042773a022224629
     name: cairo-gobject
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/c/colord-libs-1.4.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 238420
     checksum: sha256:e4324109b9812c706a3b9b828873bab78f60532e33fd37e24de8ca4930becba0
     name: colord-libs
     evr: 1.4.2-1.el8
     sourcerpm: colord-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/c/copy-jdk-configs-4.0-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 31276
     checksum: sha256:5520be18012994682dd26352095e9ddea7d63e95c557cb411048a721cd6322c8
     name: copy-jdk-configs
     evr: 4.0-2.el8
     sourcerpm: copy-jdk-configs-4.0-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/d/dconf-0.28.0-4.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 116880
     checksum: sha256:ef0980dd2f1d560e50d2e4afdbd832feccfc4aa133070ec56293114966770702
     name: dconf
     evr: 0.28.0-4.el8
     sourcerpm: dconf-0.28.0-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/f/fribidi-1.0.4-9.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 94464
     checksum: sha256:6ac3b8ed29a69ebea4c3a09cacdd4cde83f808da000bce54e10919ed542c7311
     name: fribidi
     evr: 1.0.4-9.el8
     sourcerpm: fribidi-1.0.4-9.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/gdk-pixbuf2-modules-2.36.12-7.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 118724
     checksum: sha256:8b9c94aa762de5b498a783ceef80b04b05ddda8a21a01e9a1b0dcb046c323651
     name: gdk-pixbuf2-modules
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/git-2.43.7-1.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 94860
     checksum: sha256:82c5a684aa3de13e7bba7e0c544351036599d864a55326a3832e209f3d13b935
     name: git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/git-core-2.43.7-1.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 13149784
     checksum: sha256:2b64e0733bb2e2098121db7b1d6f2f86f8053261f4e0cd40e977f64a0c49fb91
     name: git-core
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/git-core-doc-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 3216756
     checksum: sha256:09202aba03724180992d4cb6a3c617423ee25dc61f2c162990a25d7781977058
     name: git-core-doc
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/git-lfs-3.4.1-5.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 4155792
     checksum: sha256:7a6e18025e789dd1b28c1d87bfb07332fffa5a5e3dec6c5c6bbc80167a6742ba
     name: git-lfs
     evr: 3.4.1-5.el8_10
     sourcerpm: git-lfs-3.4.1-5.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/graphite2-1.3.10-10.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 131868
     checksum: sha256:e3f3593509eb4c72bdcae94b8ca0edd0e53fa156601b2966563f8e2a744151e7
     name: graphite2
     evr: 1.3.10-10.el8
     sourcerpm: graphite2-1.3.10-10.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/gtk-update-icon-cache-3.22.30-12.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 34416
     checksum: sha256:5cb13661b7737b74c8ce4c608837ba6c9be3f1e41f7547bf9f1118b800f65d8d
     name: gtk-update-icon-cache
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/g/gtk3-3.22.30-12.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 4832740
     checksum: sha256:97c0ffc33e4e956a8c9b0d57892f10ead59069c1b309f436271cd2e4d1919500
     name: gtk3
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/h/harfbuzz-1.7.5-4.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 322636
     checksum: sha256:619b87b0b60548bccd134c51a50de5483a40b70e561319ff22f22270351ea3fe
     name: harfbuzz
     evr: 1.7.5-4.el8
     sourcerpm: harfbuzz-1.7.5-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/h/hicolor-icon-theme-0.17-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 49600
     checksum: sha256:66bab4d22c2d9f29dc7c7651afa44456e306c6c9c175f96f5021b1887d9a5796
     name: hicolor-icon-theme
     evr: 0.17-2.el8
     sourcerpm: hicolor-icon-theme-0.17-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/jasper-libs-2.0.14-6.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 183868
     checksum: sha256:321e15ef25d1bb8cf14e37ad1e47bf409d658118f39c9568aea5c116f29351b7
     name: jasper-libs
     evr: 2.0.14-6.el8_10
     sourcerpm: jasper-2.0.14-6.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-17.0.16.0.8-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 536628
-    checksum: sha256:2d8cc884a76975ba71c37701922920fc2739d94b7b5cfa4dfb90a0ddd1e23ff1
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 543416
+    checksum: sha256:1d52524671d56c68936de30896dd4222be940f663e1814c195c4b0e9460bda36
     name: java-17-openjdk
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-devel-17.0.16.0.8-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 5371368
-    checksum: sha256:4e192182cd2bf6af3190cd4c7b58edc9daff190aef753c12b8e088da053a6f2e
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-devel-17.0.17.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 5371260
+    checksum: sha256:6e6d526a5c91a541817a2c9f7e3465b13d53e1c4a44908f3acd6fd3a668cdf78
     name: java-17-openjdk-devel
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-headless-17.0.16.0.8-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 47683180
-    checksum: sha256:0e529a4b96f136b35152c8af3496a2c316486774e7a8697f06abd275bf28a3ff
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 47732336
+    checksum: sha256:16e9eeb6ee1a2f9b29d4fd2f58ff826fdacef3e8247f6165f0bd817e6c00ce0e
     name: java-17-openjdk-headless
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-21.0.8.0.9-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 463512
-    checksum: sha256:b0f5756fe8d024a75e248808ebcb549e2668f46763bce6c53ccacd57cbc17ff2
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-21.0.9.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 422092
+    checksum: sha256:93b1418e0623b857fe791a72e7b7bee8aafa8fa6084de4fef5644a24872146a1
     name: java-21-openjdk
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-devel-21.0.8.0.9-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 5418652
-    checksum: sha256:6398b6b232db25b746ef1ee7d4964a2177d857854057a9eea084277396be6621
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-devel-21.0.9.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 5418176
+    checksum: sha256:6c73bd427e958f07e54226fd8686812a8ed9c60293e00972c95e7990c16ad9fe
     name: java-21-openjdk-devel
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-headless-21.0.8.0.9-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 52236424
-    checksum: sha256:9cbefc978e66eb015c519976b2217be7079ae3aec2d4c225ab5a7cab68281d23
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/java-21-openjdk-headless-21.0.9.0.10-1.el8.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 52284360
+    checksum: sha256:c1724e12f121618b7a004d19b1b27473a97de7c47285a3658c90cddbfcd0aee7
     name: java-21-openjdk-headless
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 31089
     checksum: sha256:0a2665447c6c2559229438b3cbb9b2a9c8d54886fc5cc9801d823d9991386a55
     name: javapackages-filesystem
     evr: 5.3.0-1.module+el8+2447+6f56d9a6
     sourcerpm: javapackages-tools-5.3.0-1.module+el8+2447+6f56d9a6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/jbigkit-libs-2.1-14.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 58636
     checksum: sha256:91d768369c0e8f598f3b80fb49766949bbb9605ac17702143467b4c4e498711a
     name: jbigkit-libs
     evr: 2.1-14.el8
     sourcerpm: jbigkit-2.1-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/j/jq-1.6-11.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 222152
     checksum: sha256:a025d78c664d12fc1aa0618a5f96d0ec2426876490cce200766d027614df78ff
     name: jq
     evr: 1.6-11.el8_10
     sourcerpm: jq-1.6-11.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/lcms2-2.9-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 186712
     checksum: sha256:7a40d36bb900b398e7532c47f2d24c04845bfd1723c36950630fe26100dd905c
     name: lcms2
     evr: 2.9-2.el8
     sourcerpm: lcms2-2.9-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libX11-1.6.8-9.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 667932
     checksum: sha256:82b8759cfdc5970fd99bb4b4a6a4eaa8256482f3afc4e368e036c1492271e56e
     name: libX11
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libX11-common-1.6.8-9.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 162348
     checksum: sha256:558399ee08f1281a9e2eff4c0bbc3756d374d0e543587bcf2c12e557df479cc6
     name: libX11-common
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXau-1.0.9-3.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 38756
     checksum: sha256:ea7acd3d0f14136f649d7403f0c4302cc757ddda22b8d738dae9b6f74c72c4b8
     name: libXau
     evr: 1.0.9-3.el8
     sourcerpm: libXau-1.0.9-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXcomposite-0.4.4-14.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 29624
     checksum: sha256:1559e2b1fa46e62b17a012739bb9dfe2d8a04c67d2012ba448e88c9821f0de02
     name: libXcomposite
     evr: 0.4.4-14.el8
     sourcerpm: libXcomposite-0.4.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXcursor-1.1.15-3.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 40308
     checksum: sha256:b34edb75ec140f87c736792680436874419d5510635ea904e556aec79e021126
     name: libXcursor
     evr: 1.1.15-3.el8
     sourcerpm: libXcursor-1.1.15-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXdamage-1.1.4-14.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 27796
     checksum: sha256:7afc072f7817fafbec1c19c380b10971c2a7adb4a21f17efb6403244069db5df
     name: libXdamage
     evr: 1.1.4-14.el8
     sourcerpm: libXdamage-1.1.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXext-1.3.4-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 47632
     checksum: sha256:85ac0902c707636ebc08b90981dffdc080d37b0acdec3950cfb3029779dcb823
     name: libXext
     evr: 1.3.4-1.el8
     sourcerpm: libXext-1.3.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXfixes-5.0.3-7.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 25980
     checksum: sha256:d45c6b4a0dd36d8c9448c04493e745e81315d46faab5260582dd4f6eccc289af
     name: libXfixes
     evr: 5.0.3-7.el8
     sourcerpm: libXfixes-5.0.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXft-2.3.3-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 72316
     checksum: sha256:fbe25982ea0b57de3056b5200a17966689585264be24a925fca3cef0966e843c
     name: libXft
     evr: 2.3.3-1.el8
     sourcerpm: libXft-2.3.3-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXi-1.7.10-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 51300
     checksum: sha256:80a66eb12c9c4be910fa12b7ce753e43a0af8fc0eb67625c49001930cd3b3df6
     name: libXi
     evr: 1.7.10-1.el8
     sourcerpm: libXi-1.7.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXinerama-1.1.4-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 16044
     checksum: sha256:f78454f2209be8e13f0157079c33b3a710d00c0f14b420c3907a3f31bef4fa15
     name: libXinerama
     evr: 1.1.4-1.el8
     sourcerpm: libXinerama-1.1.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXrandr-1.5.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 35020
     checksum: sha256:ae1da7ced8f6fba596cece970a7ca6704816e3ad324bef2b406e9524fbfbc25a
     name: libXrandr
     evr: 1.5.2-1.el8
     sourcerpm: libXrandr-1.5.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXrender-0.9.10-7.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 35264
     checksum: sha256:415f392bbba9e8e1c05138aa9a4a6164b9ca015ca991c7ef08f0374c86b3cc34
     name: libXrender
     evr: 0.9.10-7.el8
     sourcerpm: libXrender-0.9.10-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libXtst-1.2.3-7.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 23924
     checksum: sha256:a897c833adf903047caa7d8463fe749f6b0a871dc22dbf333c5ec9b9c373f4a4
     name: libXtst
     evr: 1.2.3-7.el8
     sourcerpm: libXtst-1.2.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libdatrie-0.2.9-7.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 35684
     checksum: sha256:0da020c68b1e76f0505d4603600b653a2cb987e7db67542b179b99ebadbd8cfd
     name: libdatrie
     evr: 0.2.9-7.el8
     sourcerpm: libdatrie-0.2.9-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libepoxy-1.5.8-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 238284
     checksum: sha256:68c5509acd50c69604eb066689444cdef1b78d66bfae1227a90fc19133870d72
     name: libepoxy
     evr: 1.5.8-1.el8
     sourcerpm: libepoxy-1.5.8-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libfontenc-1.1.3-8.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 38152
     checksum: sha256:4e3f5c8387b39ed04032310721d57d6c6a11ecb63bb1233f4110f6a257f963fa
     name: libfontenc
     evr: 1.1.3-8.el8
     sourcerpm: libfontenc-1.1.3-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libjpeg-turbo-1.5.3-14.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 175396
     checksum: sha256:4700830de70fbed3ba2bde489c71c8d92a6f244527525a08b5a6f7788a6dc9b6
     name: libjpeg-turbo
     evr: 1.5.3-14.el8_10
     sourcerpm: libjpeg-turbo-1.5.3-14.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libthai-0.1.27-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 209072
     checksum: sha256:3fce2ca6aa4f532d4e5149daa0bdda2cf80102ae844ab4543def37c0c9ed7d46
     name: libthai
     evr: 0.1.27-2.el8
     sourcerpm: libthai-0.1.27-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libtiff-4.0.9-34.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
-    size: 205404
-    checksum: sha256:8898664166c5f60675c7294dcee7579bb0cd2612abf09517455befd4294ba5fc
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libtiff-4.0.9-35.el8_10.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-appstream-rpms
+    size: 204592
+    checksum: sha256:bbb46a35119eb50344282827f72f084ed43f8a4f82cca160c9c00a57b572120f
     name: libtiff
-    evr: 4.0.9-34.el8_10
-    sourcerpm: libtiff-4.0.9-34.el8_10.src.rpm
+    evr: 4.0.9-35.el8_10
+    sourcerpm: libtiff-4.0.9-35.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libwayland-client-1.21.0-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 43956
     checksum: sha256:06224dcea3b114ec3feefa820498300fc93e08d144f37631a3a96a3d33440ca8
     name: libwayland-client
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libwayland-cursor-1.21.0-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 27356
     checksum: sha256:1ffbe6971fb812d32788253d8e1eb0efee4748a50396a7a996517a342e1c61b8
     name: libwayland-cursor
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libwayland-egl-1.21.0-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 20252
     checksum: sha256:ff50e66c2f6e224cb590f3ec1ae577a4cdbf7e4005292151239e6afbec3d71c9
     name: libwayland-egl
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/libxcb-1.13.1-1.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 244072
     checksum: sha256:2ed632face13f21a2f71f8fb3e86f90119bd74712b8c4837646c6442c8e24f53
     name: libxcb
     evr: 1.13.1-1.el8
     sourcerpm: libxcb-1.13.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/l/lua-5.3.4-12.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 206336
     checksum: sha256:b98c481c8de260f8933948f67426ff5c1f5bb44c1a226ae77d27b74645b7bb86
     name: lua
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nspr-4.36.0-2.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 156812
     checksum: sha256:7c7de7979161ccb70faa16f90aae73d161aa76efe7b341d941bc5c9ac23388c4
     name: nspr
     evr: 4.36.0-2.el8_10
     sourcerpm: nspr-4.36.0-2.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nss-3.112.0-4.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 847632
     checksum: sha256:53bfc15a51bc291b9da0c5607ee0a6b6e8d2d48e9c98ccc6b65ef6d20d00a831
     name: nss
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nss-softokn-3.112.0-4.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 585816
     checksum: sha256:327a729aaa8df832f9e7e179adb6b95774acb089208b47e3923319c4a89d6176
     name: nss-softokn
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 490032
     checksum: sha256:71d05280a27a8be51ee8572319682f1eed2da9c842d9e2569f6f023e5ceebd68
     name: nss-softokn-freebl
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 78188
     checksum: sha256:796738f57e14bd67bff8c2472656f7486a207af019c2d3c1a6c4a9f20525d089
     name: nss-sysinit
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/n/nss-util-3.112.0-4.el8_10.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 153160
     checksum: sha256:fe0443f75e491621e322fe7ddeb550f40207334420ee5805ed062920df40b7df
     name: nss-util
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 204564
     checksum: sha256:7a2b3ea4ea7a0a17ce3ece31a11fc6a21556ccba4250cd757486e07e5bf3ff3b
     name: oniguruma
     evr: 6.8.2-3.el8
     sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/pango-1.42.4-8.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 321916
     checksum: sha256:c97d6dc86f8aae76f17c294a99004b0b255d34ccfb993cd4855e9fdf7f2fcc12
     name: pango
     evr: 1.42.4-8.el8
     sourcerpm: pango-1.42.4-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Digest-MD5-2.55-396.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 38828
     checksum: sha256:c7efac801bc1b89d979c6eef9eae0fc75dc322bc15060b8cdc396fe1def0564b
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Git-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 81136
     checksum: sha256:cc2b622933dabf0579711ce3fdccfd5b485483b8b0f8ed4dc2df3d59842ba735
     name: perl-Git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 390810
     checksum: sha256:76fb7e521ced6db01aa523228c143305d242df2c6617d95596fc2109e4d49822
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 42972
     checksum: sha256:c39803f28ce1946f2c7d901e65768f47ee6db7258d88b0799c3d102986a3245f
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/p/pixman-0.38.4-4.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 205592
     checksum: sha256:bd21dc612eebcf4145c629b6b904c6dd906784e04427475883246dddea596d6f
     name: pixman
     evr: 0.38.4-4.el8
     sourcerpm: pixman-0.38.4-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/r/rest-0.8.1-2.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 73492
     checksum: sha256:0db8f4f427bee7167624c22a2ec275bb95acc43d776f9385500146d2416209e5
     name: rest
     evr: 0.8.1-2.el8
     sourcerpm: rest-0.8.1-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/t/ttmkfdir-3.0.9-54.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 63716
     checksum: sha256:1218eafaa5773868ec74c4e8bc8dd08c126311ae9af05dd9b7b585cbae4fdde2
     name: ttmkfdir
     evr: 3.0.9-54.el8
     sourcerpm: ttmkfdir-3.0.9-54.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/t/tzdata-java-2025b-1.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 191116
     checksum: sha256:3fa146aae879f61ff54642ba5b8b2922ef49b09c2a931ad4314b4137fd884175
     name: tzdata-java
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/x/xmlstarlet-1.6.1-20.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 83436
     checksum: sha256:cbe092cdb983d2f3dfbd70706931b0ae24acdc80b2465b14ee27bd11e88f4e07
     name: xmlstarlet
     evr: 1.6.1-20.el8
     sourcerpm: xmlstarlet-1.6.1-20.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/x/xorg-x11-font-utils-7.5-41.el8.ppc64le.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 115628
     checksum: sha256:fa5f7c407f3d288c337e8587e53f47098b6be5116adf4378498bbd2a0d39a132
     name: xorg-x11-font-utils
     evr: 1:7.5-41.el8
     sourcerpm: xorg-x11-font-utils-7.5-41.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/Packages/x/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 534388
     checksum: sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae
     name: xorg-x11-fonts-Type1
     evr: 7.5-19.el8
     sourcerpm: xorg-x11-fonts-7.5-19.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/a/avahi-libs-0.7-27.el8_10.1.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 68544
     checksum: sha256:a3669c396a6f84e91dfabb5832073f78956e8d0e90e5d13ed8fc9202a4e02e27
     name: avahi-libs
     evr: 0.7-27.el8_10.1
     sourcerpm: avahi-0.7-27.el8_10.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/b/bc-1.07.1-5.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 135940
     checksum: sha256:0ec21164642fdc03a56ebcdeb4691ee5db63f8da78a2762bb5b8d86398ca432f
     name: bc
     evr: 1.07.1-5.el8
     sourcerpm: bc-1.07.1-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/b/bzip2-1.0.6-28.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 63168
     checksum: sha256:4c1c90dc5d60ace35e64957278cd90e9ada5f6294dcf9ebd263e8c9c5f6edff7
     name: bzip2
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/c/cups-libs-2.2.6-63.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 503612
     checksum: sha256:2cde7b5a3ea47e637be7665c8cc5dcbe62bed14d210171b2d4249115a80f8b5c
     name: cups-libs
     evr: 1:2.2.6-63.el8_10
     sourcerpm: cups-2.2.6-63.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/d/dejavu-fonts-common-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 76096
     checksum: sha256:82f36244bf29111473619a3565e69d3e8213e829d8eaf3e141c6c397d574ccf3
     name: dejavu-fonts-common
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/d/dejavu-sans-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 1558464
     checksum: sha256:488d2b14e88a91dfe40d5dbf9136f29b155d1fe22f6a6c442db528684cb55e95
     name: dejavu-sans-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/d/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 457788
     checksum: sha256:bb4b2ae2789e9295d835c3c48705f5bd7f6813613f91faab19d4bcb37300b1c2
     name: dejavu-sans-mono-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/e/emacs-filesystem-26.1-15.el8_10.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 72500
     checksum: sha256:3752a72be8d33b701a01e746dc2f8d56e2ba7829baa5f2bf3f1a590d8267c60a
     name: emacs-filesystem
     evr: 1:26.1-15.el8_10
     sourcerpm: emacs-26.1-15.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/f/fontconfig-2.13.1-4.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 301800
     checksum: sha256:6332950fd45ec7ef166a83c46fa496b41caa69377856e8553e04258270bbdfe0
     name: fontconfig
     evr: 2.13.1-4.el8
     sourcerpm: fontconfig-2.13.1-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/f/fontpackages-filesystem-1.44-22.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 16324
     checksum: sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0
     name: fontpackages-filesystem
     evr: 1.44-22.el8
     sourcerpm: fontpackages-1.44-22.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/f/freetype-2.9.1-10.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 440944
     checksum: sha256:05277110192ee7f869fc74ead7acb1f4a8c34be8aa9ef18dc52b4144ed06ac38
     name: freetype
     evr: 2.9.1-10.el8_10
     sourcerpm: freetype-2.9.1-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/gdk-pixbuf2-2.36.12-7.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 483560
     checksum: sha256:4874d241f292fc1cdbc02fe39e2e0e768d7eb04ba8f47d0f3b5f03685864b712
     name: gdk-pixbuf2
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 1125644
     checksum: sha256:f14b5f40e96ae727ce58c415295141645910311915d79d446403f68ff416ebad
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 339476
     checksum: sha256:eec4945093aa8b86e3c3a8ed629499ac3478be1e5f0a89d74178e277a7484750
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/glib-networking-2.56.1-1.1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 162044
     checksum: sha256:8592c632ab75709f66c5fe6b49ce424a2ddd390f7bf01ee768425b3e60801fec
     name: glib-networking
     evr: 2.56.1-1.1.el8
     sourcerpm: glib-networking-2.56.1-1.1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/glibc-locale-source-2.28-251.el8_10.25.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 4418700
     checksum: sha256:08c1aeed17a8b88021099839e6dcb3502bde769e456b2c6df6aa0b862e991362
     name: glibc-locale-source
     evr: 2.28-251.el8_10.25
     sourcerpm: glibc-2.28-251.el8_10.25.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/groff-base-1.22.3-18.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 1091964
     checksum: sha256:35598d36ec3edefc4bae80f0a5b345a254ae686aa913dc92ac04d6855331c037
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/g/gsettings-desktop-schemas-3.32.0-6.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 648052
     checksum: sha256:7aeefb12b6e69ae7090dea3efbf0f7b86b4fb7b03a09a77be01c96ab695704aa
     name: gsettings-desktop-schemas
     evr: 3.32.0-6.el8
     sourcerpm: gsettings-desktop-schemas-3.32.0-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/less-530-3.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 178908
     checksum: sha256:4dd00220fe796e59ca5b00868e5984c15c2a2a3b778ea3fabb35ba521eca37e0
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 126044
     checksum: sha256:9a1782b0ff33ad11979c039999990819c66145010e17c4af41550daf4d9d15ae
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 112464
     checksum: sha256:7f8760b668bc465f9e538da9bfa281d1c881d05611ba54a0ac38a97338694ce2
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libgomp-8.5.0-28.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 219356
     checksum: sha256:f39bd24457f4bfe7fbee225a0c0dd6cc79b292160114abce74e56cb59881151a
     name: libgomp
     evr: 8.5.0-28.el8_10
     sourcerpm: gcc-8.5.0-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libgusb-0.3.0-1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 50672
     checksum: sha256:6eaa102d4a683896d11915903c2d4b958a810d9ef8563a9a9946258bc11306c9
     name: libgusb
     evr: 0.3.0-1.el8
     sourcerpm: libgusb-0.3.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libmodman-2.0.1-17.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 37528
     checksum: sha256:a660a0ed20a7d6fd7caa88d85f92575cfa21d207c059aab380fa82c4742a1634
     name: libmodman
     evr: 2.0.1-17.el8
     sourcerpm: libmodman-2.0.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 39284
     checksum: sha256:be44b47bbd3f227e25f645728e55022bbe5206afa76a955f6629bc50fe9abc53
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libpng-1.6.34-5.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 143108
     checksum: sha256:d42e36ab818d9284eb5fb9d46a0af71d99b91d917b3fdf1ac9af3ebd473606f1
     name: libpng
     evr: 2:1.6.34-5.el8
     sourcerpm: libpng-1.6.34-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libproxy-0.4.15-5.5.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 76460
     checksum: sha256:65aeaba2d36b4a5cffc16ed16d34d036aea6f17fa4c8bc4acb6851d2573b1b70
     name: libproxy
     evr: 0.4.15-5.5.el8_10
     sourcerpm: libproxy-0.4.15-5.5.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libsoup-2.62.3-9.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
-    size: 448360
-    checksum: sha256:faa91734fa9aa575c4f413e08d736b313c6cd2e742b35614deff70417226b9f2
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libsoup-2.62.3-10.el8_10.ppc64le.rpm
+    repoid: ubi-8-for-ppc64le-baseos-rpms
+    size: 447888
+    checksum: sha256:c19a8fe4d3902a1c448810ab03a39eebf8edc617f55c1cae8d18f4677e0a87d3
     name: libsoup
-    evr: 2.62.3-9.el8_10
-    sourcerpm: libsoup-2.62.3-9.el8_10.src.rpm
+    evr: 2.62.3-10.el8_10
+    sourcerpm: libsoup-2.62.3-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/libxslt-1.1.32-6.3.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 267720
     checksum: sha256:92b232076824fdfdb889acc43dd5fce532f980f274a0a8b3e464ea379440b4c3
     name: libxslt
     evr: 1.1.32-6.3.el8_10
     sourcerpm: libxslt-1.1.32-6.3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/l/lksctp-tools-1.0.18-3.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 103852
     checksum: sha256:2f31b6b30b2088774b084804099d462c08dc2f6aa24c730748465db0effd7c8f
     name: lksctp-tools
     evr: 1.0.18-3.el8
     sourcerpm: lksctp-tools-1.0.18-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 402196
     checksum: sha256:6acd630f4fb7cd5404c5b0e1f5d3a1c0c4d22e63b60766240a2cb0dc997a440e
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/o/openssh-8.0p1-26.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 535800
     checksum: sha256:f1569cc43116ed43b49ed93f1724d695be285f58a4e9258efe78164c53f2ab48
     name: openssh
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/o/openssh-clients-8.0p1-26.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 705696
     checksum: sha256:b029695f5b66b2c01464fcc20455173de899b707104bd51930e0eb8e7ff6f0cd
     name: openssh-clients
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 59924
     checksum: sha256:481d6065068ab8fd3bef7fa0539e73ca8ede56ecb652dc3974eb7d2244670aee
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Encode-2.97-3.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 1530288
     checksum: sha256:3ee2ccbfee32f806afec5a5e873423d49c5ba88a3c425b98663ac95be4c62a10
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Errno-1.28-423.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 78560
     checksum: sha256:d29c5b60625a6faaf7c0a1aae9465af300c633833d6d519caa04bdd3010baff6
     name: perl-Errno
     evr: 1.28-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-IO-1.38-423.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 146620
     checksum: sha256:73ad1e301d52e0cdd3a0d292ea8bdeda66441661baa680f225941a76604a44ef
     name: perl-IO
     evr: 1.38-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 32240
     checksum: sha256:44e0e3afc547cbbff4a3ae8a8788712bf2917ff5050dc6fcf969cf78b71d385e
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 93220
     checksum: sha256:759d2a6cb209926af2799c1f25851e28a34f6af7e55f93a68045776bb2519379
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 72272
     checksum: sha256:abf49a75e3221dce4a379c9300b15611dc4a45acc109862e88146441776d0343
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Socket-2.027-3.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 60844
     checksum: sha256:941fb8859ba0911c8d42d7fadb9a70e89155013f3fa697bb61ba5a18661a1d45
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Storable-3.11-3.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 102044
     checksum: sha256:8d54cc441cf480bc016c027df4acfd938373a19d91a7fd00749e4d2de3c36bfd
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 82096
     checksum: sha256:ec12527a8c08222f2d4552bd2a5c1729764c180950fe5fec9ca4dcb97e4099c6
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-interpreter-5.26.3-423.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 6634128
     checksum: sha256:a01254fd14fb9d98c380b9853fe9e710a7d0c00065babea4160cce85d23076f6
     name: perl-interpreter
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-libs-5.26.3-423.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 1657264
     checksum: sha256:e4531d816f79aa1e151ec788f3b609bf12b1fdfd7e84032ac54ba27916b3adea
     name: perl-libs
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-macros-5.26.3-423.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 74456
     checksum: sha256:460ab3ad02225239e16c022d8ef68e3b3bc834792aea357a39cc391619203a33
     name: perl-macros
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-threads-2.21-2.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 63064
     checksum: sha256:ac56f03020c08a0e56aa90d369d68ed6c558786b828c575b266c3e7967eae61d
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 50192
     checksum: sha256:e1f1f3beb08cd5f29b2daa92593822fdd2c5af843b0532b0e8925180e3e931a2
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 39616
     checksum: sha256:5247ecf6db41cf55db819e36b36be26806bac55d542183e8375177f582420035
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 15616
     checksum: sha256:0a5344c56c015390b8e0e638246f3ccfef654bf185735b8f8238ef804f9912eb
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/u/unzip-6.0-48.el8_10.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 203072
     checksum: sha256:07c7b785c7d3459b0e7c735fef86725be614212ffc242346c0166ac4bdf209b8
     name: unzip
     evr: 6.0-48.el8_10
     sourcerpm: unzip-6.0-48.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/baseos/os/Packages/z/zip-3.0-23.el8.ppc64le.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-ppc64le-baseos-rpms
     size: 281980
     checksum: sha256:2ac73172a362eab73d3f9cc5369438f54c8d5c308713000cc55ece73963b03ad
     name: zip
@@ -2198,1099 +2198,1099 @@ arches:
     sourcerpm: zip-3.0-23.el8.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/repodata/f0eb747a7775dd5474d980774e8f7e5d793c0373c4ca2303a452022681247e0b-modules.yaml.gz
-    repoid: ubi-8-appstream
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/ppc64le/appstream/os/repodata/f14f74f99cc728c4f145ec3a007603931036ce92d9bf7edfbfb0f0599ed76b33-modules.yaml.gz
+    repoid: ubi-8-for-ppc64le-appstream-rpms
     size: 55946
-    checksum: sha256:f0eb747a7775dd5474d980774e8f7e5d793c0373c4ca2303a452022681247e0b
+    checksum: sha256:f14f74f99cc728c4f145ec3a007603931036ce92d9bf7edfbfb0f0599ed76b33
 - arch: s390x
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 159316
     checksum: sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c
     name: abattis-cantarell-fonts
     evr: 0.0.25-6.el8
     sourcerpm: abattis-cantarell-fonts-0.0.25-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/adwaita-cursor-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 662496
     checksum: sha256:1672a332f0108712757853e99e63fc9f659fe14cfc3d36b6e36ce07c564ef05a
     name: adwaita-cursor-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/adwaita-icon-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 11982852
     checksum: sha256:99cf2d2181327417b07c83fd999749774046330f5ca24991d3eb4d967aed6bae
     name: adwaita-icon-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/alsa-lib-1.2.10-2.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 480188
     checksum: sha256:6de753a7b137ef37731e49a41502de40f4609e9e2c3766ad4feff8ccccc6e329
     name: alsa-lib
     evr: 1.2.10-2.el8
     sourcerpm: alsa-lib-1.2.10-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/at-spi2-atk-2.26.2-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 87108
     checksum: sha256:0b40c88c5f33353cc1fead9a2c354e709645bffd1f5f283a55afe5f0aad309a7
     name: at-spi2-atk
     evr: 2.26.2-1.el8
     sourcerpm: at-spi2-atk-2.26.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/at-spi2-core-2.28.0-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 166316
     checksum: sha256:296c6760b154158a39843c1def0e60092c50f05b92e7111d18a16cbafa943f54
     name: at-spi2-core
     evr: 2.28.0-1.el8
     sourcerpm: at-spi2-core-2.28.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/a/atk-2.28.1-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 275928
     checksum: sha256:8c900cc24fa6d8094f00440263357a6fbb4675332df0b12c1129a847df4f2abe
     name: atk
     evr: 2.28.1-1.el8
     sourcerpm: atk-2.28.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/c/cairo-1.15.12-6.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 687440
     checksum: sha256:f07220fab173d0d154402651b0fc8445508fa8bf13fab649bc39c4564417c81b
     name: cairo
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/c/cairo-gobject-1.15.12-6.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 33732
     checksum: sha256:53f30ed494b4359152c291d3f3d6b9f07939e3b311fd1e748c5afb53df47f208
     name: cairo-gobject
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/c/colord-libs-1.4.2-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 222680
     checksum: sha256:b454f0d7044952dc98d0b4a92477d3a799113afde0b5e06f7cf4ad23f9b4643b
     name: colord-libs
     evr: 1.4.2-1.el8
     sourcerpm: colord-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/c/copy-jdk-configs-4.0-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 31276
     checksum: sha256:5520be18012994682dd26352095e9ddea7d63e95c557cb411048a721cd6322c8
     name: copy-jdk-configs
     evr: 4.0-2.el8
     sourcerpm: copy-jdk-configs-4.0-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/d/dconf-0.28.0-4.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 105588
     checksum: sha256:c7da1590f7251a854013b6127c0fa7367a2579d4201fcdd6165aa8f019f6a002
     name: dconf
     evr: 0.28.0-4.el8
     sourcerpm: dconf-0.28.0-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/f/fribidi-1.0.4-9.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 91808
     checksum: sha256:6073e3cd742949548f266f822fc9fd01fa65fae9a9dd195c8c47eedd8d86bf73
     name: fribidi
     evr: 1.0.4-9.el8
     sourcerpm: fribidi-1.0.4-9.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/gdk-pixbuf2-modules-2.36.12-7.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 105772
     checksum: sha256:0475f913adc366c9590a1e321e13f3086dbafa23c1e0a4a58a6fbc6e78f969ae
     name: gdk-pixbuf2-modules
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/git-2.43.7-1.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 94880
     checksum: sha256:11cb5de7f2c20cf19598ed25573c5c770e1f2111b6fb8ce2aec43069071e3fb8
     name: git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/git-core-2.43.7-1.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 11034972
     checksum: sha256:713ab39f22985d648d355541b3331ef10d0536910071561fae19f4950c95ba84
     name: git-core
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/git-core-doc-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 3216756
     checksum: sha256:09202aba03724180992d4cb6a3c617423ee25dc61f2c162990a25d7781977058
     name: git-core-doc
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/git-lfs-3.4.1-5.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 4390588
     checksum: sha256:097e0940a55d4afcab5bc1fe68116bdfc1b8837c8a1d162a635dac6536eadf67
     name: git-lfs
     evr: 3.4.1-5.el8_10
     sourcerpm: git-lfs-3.4.1-5.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/graphite2-1.3.10-10.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 115052
     checksum: sha256:c2710a99f424d04c1ee0a24c219918be5c53c3661fc6e01522254768859381ee
     name: graphite2
     evr: 1.3.10-10.el8
     sourcerpm: graphite2-1.3.10-10.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/gtk-update-icon-cache-3.22.30-12.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 32576
     checksum: sha256:117848acb3dd128d4a80b8e93c5579e4974f64976dbc3b1d504cb040b9491cd2
     name: gtk-update-icon-cache
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/g/gtk3-3.22.30-12.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 4489236
     checksum: sha256:ad9048cf79442c5029ab6afa66e4f624bbfcaca970b7ddc4f1a495011ad4fbcb
     name: gtk3
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/h/harfbuzz-1.7.5-4.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 290620
     checksum: sha256:20b79d317a38e1e8dc3e2c3e879a1ca988b7ac6541668106bf713ce867017e04
     name: harfbuzz
     evr: 1.7.5-4.el8
     sourcerpm: harfbuzz-1.7.5-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/h/hicolor-icon-theme-0.17-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 49600
     checksum: sha256:66bab4d22c2d9f29dc7c7651afa44456e306c6c9c175f96f5021b1887d9a5796
     name: hicolor-icon-theme
     evr: 0.17-2.el8
     sourcerpm: hicolor-icon-theme-0.17-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/jasper-libs-2.0.14-6.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 162876
     checksum: sha256:0602ba39cc7c74e14a16c2dacb9270a22eb79b34d71ecd00e8a4bd65d7947da0
     name: jasper-libs
     evr: 2.0.14-6.el8_10
     sourcerpm: jasper-2.0.14-6.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 417896
     checksum: sha256:58723de3cdc7c3cd277568bdb72cd6ad921e073c0a0d5dd312ccec8a3acb23b2
     name: java-17-openjdk
     evr: 1:17.0.17.0.10-1.el8
     sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-17-openjdk-devel-17.0.17.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 5366456
     checksum: sha256:056e12a4f9e6f0c3104fdca51f4aa0c9911606e00e02aa9937a9e0eeb18176f0
     name: java-17-openjdk-devel
     evr: 1:17.0.17.0.10-1.el8
     sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 44506724
     checksum: sha256:8373fb7328b8cb5cea709a3298a88d177d0a629cc3edabee9e8ec0f241ccfeb6
     name: java-17-openjdk-headless
     evr: 1:17.0.17.0.10-1.el8
     sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-21-openjdk-21.0.9.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 330252
     checksum: sha256:5b3e09e96b1c6650cefed5f92e0a5b07a178ecd6a0e1bf1271254951c8f400a7
     name: java-21-openjdk
     evr: 1:21.0.9.0.10-1.el8
     sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-21-openjdk-devel-21.0.9.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 5413504
     checksum: sha256:3c0e10da149a5762190e9a56f364e7ce9f6728e51236f56562c2bf7c6bfaec53
     name: java-21-openjdk-devel
     evr: 1:21.0.9.0.10-1.el8
     sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/java-21-openjdk-headless-21.0.9.0.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 48709972
     checksum: sha256:4736592ed0c4c7f60aa6188965dcf04c386c6756acbedc908be707a61b7719a7
     name: java-21-openjdk-headless
     evr: 1:21.0.9.0.10-1.el8
     sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 31089
     checksum: sha256:0a2665447c6c2559229438b3cbb9b2a9c8d54886fc5cc9801d823d9991386a55
     name: javapackages-filesystem
     evr: 5.3.0-1.module+el8+2447+6f56d9a6
     sourcerpm: javapackages-tools-5.3.0-1.module+el8+2447+6f56d9a6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/jbigkit-libs-2.1-14.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 55400
     checksum: sha256:7b250a6c271deb7c12634590181632ab8088b5b0f32cc90bad3358e27f03c43a
     name: jbigkit-libs
     evr: 2.1-14.el8
     sourcerpm: jbigkit-2.1-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/j/jq-1.6-11.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 213148
     checksum: sha256:975481360f19614d4d7d0eb843aa030f11ca47d4858c2d744ffb3a6c0cf718b0
     name: jq
     evr: 1.6-11.el8_10
     sourcerpm: jq-1.6-11.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/lcms2-2.9-2.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 158760
     checksum: sha256:59938938c0379019c98c1a6499e685c7707f688e9d3d69880e6a883362936ee3
     name: lcms2
     evr: 2.9-2.el8
     sourcerpm: lcms2-2.9-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libX11-1.6.8-9.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 607176
     checksum: sha256:3a8e1bb12851c922108231cf7dea1e5a5414d1c6b2fc0d4d5ee4fe60f1091d4f
     name: libX11
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libX11-common-1.6.8-9.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 162348
     checksum: sha256:558399ee08f1281a9e2eff4c0bbc3756d374d0e543587bcf2c12e557df479cc6
     name: libX11-common
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXau-1.0.9-3.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 37932
     checksum: sha256:e3dd559d2df14bd0a07fa9b3139a222a0614cd20ba3ab2f67c3e7c7cbea5bc9d
     name: libXau
     evr: 1.0.9-3.el8
     sourcerpm: libXau-1.0.9-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXcomposite-0.4.4-14.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 28908
     checksum: sha256:c469da656f4668129debc5cd0a0d99cea70b1c8cdc9e86b956263d29ebd40eb8
     name: libXcomposite
     evr: 0.4.4-14.el8
     sourcerpm: libXcomposite-0.4.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXcursor-1.1.15-3.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 36984
     checksum: sha256:5f15a4bf77f6442ea7b64caa30b8f61d3b0ef3cb95468a927b25f4dcc6fe677a
     name: libXcursor
     evr: 1.1.15-3.el8
     sourcerpm: libXcursor-1.1.15-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXdamage-1.1.4-14.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 26972
     checksum: sha256:4aa9d3f4a375249229aa8a8f3d7b8e6fb162e67eb14bf8ce92d31763447d399b
     name: libXdamage
     evr: 1.1.4-14.el8
     sourcerpm: libXdamage-1.1.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXext-1.3.4-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 44200
     checksum: sha256:b334adec936dd57a63d87f71918c66126ac545ca49dec2c36efed23a58e57f79
     name: libXext
     evr: 1.3.4-1.el8
     sourcerpm: libXext-1.3.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXfixes-5.0.3-7.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 24692
     checksum: sha256:7d4fa3a544eb7f5e6debd356d7498b440467382864d64ee3a9a5324813c51811
     name: libXfixes
     evr: 5.0.3-7.el8
     sourcerpm: libXfixes-5.0.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXft-2.3.3-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 66760
     checksum: sha256:cc29ba88889c4207d199aaf4463e52f1e73a3bf1d95f9b3b45f8a20789e10442
     name: libXft
     evr: 2.3.3-1.el8
     sourcerpm: libXft-2.3.3-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXi-1.7.10-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 46840
     checksum: sha256:391b11ad54092e7ccbb9631fb258c648ef77a9baf46dd42561dd457116666bc6
     name: libXi
     evr: 1.7.10-1.el8
     sourcerpm: libXi-1.7.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXinerama-1.1.4-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 15544
     checksum: sha256:bf302ac966ade9867e2df9c77e3ee57bc1dee265c6c889f43ba43dcfbf696ca3
     name: libXinerama
     evr: 1.1.4-1.el8
     sourcerpm: libXinerama-1.1.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXrandr-1.5.2-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 33144
     checksum: sha256:470739c4a606b933acfb6b232d55e28cc7e82ec069bfdf9b885b2b0ca383422d
     name: libXrandr
     evr: 1.5.2-1.el8
     sourcerpm: libXrandr-1.5.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXrender-0.9.10-7.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 32280
     checksum: sha256:cc5a2d1f5209e14cbb310a77cf13537f2859ba118c4d03ac882621d015825b7d
     name: libXrender
     evr: 0.9.10-7.el8
     sourcerpm: libXrender-0.9.10-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libXtst-1.2.3-7.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 21628
     checksum: sha256:a1781411c7a2f29ed052ce6117a1f4aa9195e7ae1b2707241a12b40c82663232
     name: libXtst
     evr: 1.2.3-7.el8
     sourcerpm: libXtst-1.2.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libdatrie-0.2.9-7.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 33596
     checksum: sha256:2abf6732c19943b5a1c18417a877cb5a1498e451620f2e4323af839b8e5b2829
     name: libdatrie
     evr: 0.2.9-7.el8
     sourcerpm: libdatrie-0.2.9-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libepoxy-1.5.8-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 226348
     checksum: sha256:8b38ffa5911d5ea59edf793574a4e2175bc67ea94c932afe24fb680ce960dee0
     name: libepoxy
     evr: 1.5.8-1.el8
     sourcerpm: libepoxy-1.5.8-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libfontenc-1.1.3-8.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 37628
     checksum: sha256:fe7258104a4cbafaa3ae30f6826dea4fdcfaab74a91f84f216ba1d0326a10390
     name: libfontenc
     evr: 1.1.3-8.el8
     sourcerpm: libfontenc-1.1.3-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libjpeg-turbo-1.5.3-14.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 152792
     checksum: sha256:4e77b6b096396120b05efb42938a31849e6efa0311f30273a9cec23060c57102
     name: libjpeg-turbo
     evr: 1.5.3-14.el8_10
     sourcerpm: libjpeg-turbo-1.5.3-14.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libthai-0.1.27-2.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 207796
     checksum: sha256:155c47c9c30fc34035e974711622d2f9e6c71eb515434d92ecec7a5a866f9bb8
     name: libthai
     evr: 0.1.27-2.el8
     sourcerpm: libthai-0.1.27-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libtiff-4.0.9-34.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
-    size: 186452
-    checksum: sha256:fc5d9ae2206bf9f45fe0dd964875f496677a087418c0c3f1380262341b1d961a
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libtiff-4.0.9-35.el8_10.s390x.rpm
+    repoid: ubi-8-for-s390x-appstream-rpms
+    size: 185456
+    checksum: sha256:677c7f7ae01729bffc149d43ccd7360c64a986e1b4a13150de0a86467dffdb64
     name: libtiff
-    evr: 4.0.9-34.el8_10
-    sourcerpm: libtiff-4.0.9-34.el8_10.src.rpm
+    evr: 4.0.9-35.el8_10
+    sourcerpm: libtiff-4.0.9-35.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libwayland-client-1.21.0-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 40764
     checksum: sha256:39a89f08649f1322bff7f7ea0c51b66908d7dc3bba3645dafccca8e1ea9dad0c
     name: libwayland-client
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libwayland-cursor-1.21.0-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 26340
     checksum: sha256:62040a67105d74a315bf55883837cedaa1f5f91f288e0cff47f94de43d9ed86e
     name: libwayland-cursor
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libwayland-egl-1.21.0-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 19872
     checksum: sha256:248a7f2e7832d1d259c05335ffbd49598a7b0f5c1fb9ec33cb1c44a482c19d79
     name: libwayland-egl
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/libxcb-1.13.1-1.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 226760
     checksum: sha256:e63f327c851c2a89254ead31b682e8f9fdb53806c6dea797dd72de18be837ff2
     name: libxcb
     evr: 1.13.1-1.el8
     sourcerpm: libxcb-1.13.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/l/lua-5.3.4-12.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 193800
     checksum: sha256:8f1b2d7537c59195eec9ea0cd682092ef982f13afb31cacd281e5de304c16852
     name: lua
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nspr-4.36.0-2.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 143356
     checksum: sha256:2bd2fee8e87f232e9aa0eaa064e29343f620fc3d30f0485c77814be6e154293d
     name: nspr
     evr: 4.36.0-2.el8_10
     sourcerpm: nspr-4.36.0-2.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nss-3.112.0-4.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 733584
     checksum: sha256:a1080570c4bf3b2b8edd84da850c0764ea9eb9e2b95915df62a9c299552dabbc
     name: nss
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nss-softokn-3.112.0-4.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 530124
     checksum: sha256:6f54e2d6afd9901be9d19a577855498e6f02a76c82f6f2f287b319529f534cfe
     name: nss-softokn
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 445848
     checksum: sha256:e873130024b2c643a0c00480bae85d83b55226d3b96aa84c5d11f1af325dc6d5
     name: nss-softokn-freebl
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 77756
     checksum: sha256:9853799693b131b3897ecb7f873a6bf81b9729f14223627b28aaaba3b581c8c1
     name: nss-sysinit
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/n/nss-util-3.112.0-4.el8_10.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 143840
     checksum: sha256:4230cb1e0257aa1f115ef67db93c6a4a0beb4c7726bd139f587cac6b2dbd52c2
     name: nss-util
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 188988
     checksum: sha256:baca7bba0f15b43f62307570e6e9153e6cef5f8cfcad07c5177f1d7a299203d9
     name: oniguruma
     evr: 6.8.2-3.el8
     sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/pango-1.42.4-8.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 294144
     checksum: sha256:913f36f3b09afb78872fae053fdf79e1f8a46fb867fd61d6be35fcf733c2aaff
     name: pango
     evr: 1.42.4-8.el8
     sourcerpm: pango-1.42.4-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Digest-MD5-2.55-396.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 37692
     checksum: sha256:7b6a754b55749e5f11ffec19cbb711f570607c2230e5750e5b2aaa915aa765c7
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Git-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 81136
     checksum: sha256:cc2b622933dabf0579711ce3fdccfd5b485483b8b0f8ed4dc2df3d59842ba735
     name: perl-Git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 369690
     checksum: sha256:d9768eacf84b11dea4a0fc2f6f03f4fb2e674df6939f500d0f6ec42a9635b66b
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 40184
     checksum: sha256:26219fa130713bece304833e8c917b8050563accdf48841c03269ece91501a62
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/p/pixman-0.38.4-4.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 163876
     checksum: sha256:726e6bc1dbf5052f7281915717972a7929de217e5742b41d7bf630c2816e6a5c
     name: pixman
     evr: 0.38.4-4.el8
     sourcerpm: pixman-0.38.4-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/r/rest-0.8.1-2.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 69120
     checksum: sha256:0e4f4d23f34e54007a6785ef2b90fc7d8e38de6979ff63d841d6d33e360c232f
     name: rest
     evr: 0.8.1-2.el8
     sourcerpm: rest-0.8.1-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/t/ttmkfdir-3.0.9-54.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 61032
     checksum: sha256:37b4d4bf46b702cd7cf8189c92dd0fcc09bdd322b61e2f401a40bb378455a917
     name: ttmkfdir
     evr: 3.0.9-54.el8
     sourcerpm: ttmkfdir-3.0.9-54.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/t/tzdata-java-2025b-1.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 191116
     checksum: sha256:3fa146aae879f61ff54642ba5b8b2922ef49b09c2a931ad4314b4137fd884175
     name: tzdata-java
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/x/xmlstarlet-1.6.1-20.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 69944
     checksum: sha256:2ca7ae724d8ca52b3d825f476c2b5a3e63c5cd4a287eebbbdcdbc8b9d2568f1e
     name: xmlstarlet
     evr: 1.6.1-20.el8
     sourcerpm: xmlstarlet-1.6.1-20.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/x/xorg-x11-font-utils-7.5-41.el8.s390x.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 103480
     checksum: sha256:5c6e8b8986e651049cb100ae2221782a3a7f16615896839856f3ef19527e67af
     name: xorg-x11-font-utils
     evr: 1:7.5-41.el8
     sourcerpm: xorg-x11-font-utils-7.5-41.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/Packages/x/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 534388
     checksum: sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae
     name: xorg-x11-fonts-Type1
     evr: 7.5-19.el8
     sourcerpm: xorg-x11-fonts-7.5-19.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/a/avahi-libs-0.7-27.el8_10.1.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 60136
     checksum: sha256:00ad7c824b1f316b17539965395e6cf0124abf92acbe517cf910809d7017744c
     name: avahi-libs
     evr: 0.7-27.el8_10.1
     sourcerpm: avahi-0.7-27.el8_10.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/b/bc-1.07.1-5.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 131280
     checksum: sha256:d11968fde78fd60b397319b360da67e1ae6268ba1861326ee0fb0ccf4eb9a739
     name: bc
     evr: 1.07.1-5.el8
     sourcerpm: bc-1.07.1-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/b/bzip2-1.0.6-28.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 61640
     checksum: sha256:8e15ec06b3d89b5b84cfb81d3cd18df1822517dee1d3e4de7df1b2262f484736
     name: bzip2
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/c/cups-libs-2.2.6-63.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 422036
     checksum: sha256:aa6efb3d800c24cc99e1d9a08e9adb201398aca19e1f76cbaba3d189cac7129a
     name: cups-libs
     evr: 1:2.2.6-63.el8_10
     sourcerpm: cups-2.2.6-63.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/d/dejavu-fonts-common-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 76096
     checksum: sha256:82f36244bf29111473619a3565e69d3e8213e829d8eaf3e141c6c397d574ccf3
     name: dejavu-fonts-common
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/d/dejavu-sans-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 1558464
     checksum: sha256:488d2b14e88a91dfe40d5dbf9136f29b155d1fe22f6a6c442db528684cb55e95
     name: dejavu-sans-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/d/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 457788
     checksum: sha256:bb4b2ae2789e9295d835c3c48705f5bd7f6813613f91faab19d4bcb37300b1c2
     name: dejavu-sans-mono-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/e/emacs-filesystem-26.1-15.el8_10.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 72500
     checksum: sha256:3752a72be8d33b701a01e746dc2f8d56e2ba7829baa5f2bf3f1a590d8267c60a
     name: emacs-filesystem
     evr: 1:26.1-15.el8_10
     sourcerpm: emacs-26.1-15.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/f/fontconfig-2.13.1-4.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 275964
     checksum: sha256:8f358e94ac789a4718858107e7aa191e8b64566c9731c0d1d9b557c6fe3f8bec
     name: fontconfig
     evr: 2.13.1-4.el8
     sourcerpm: fontconfig-2.13.1-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/f/fontpackages-filesystem-1.44-22.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 16324
     checksum: sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0
     name: fontpackages-filesystem
     evr: 1.44-22.el8
     sourcerpm: fontpackages-1.44-22.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/f/freetype-2.9.1-10.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 383740
     checksum: sha256:d848212792121ac434dba44b8503311d5105b70afd70b2c794d68969afcd6ebd
     name: freetype
     evr: 2.9.1-10.el8_10
     sourcerpm: freetype-2.9.1-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/gdk-pixbuf2-2.36.12-7.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 473340
     checksum: sha256:5e32bd202dc9e3da591da2febc24c1ba180a5b9f02e313a2d5a6d44af7538628
     name: gdk-pixbuf2
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 1098512
     checksum: sha256:2b75a5e095f83147fbfabda96e6e3bfd7257481425e410c8b063a75cec171ce5
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 300720
     checksum: sha256:496ce9d92ab1f19e0e6c8580b4acc9dc73fe4517d53f7b0cfc976511032c328f
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/glib-networking-2.56.1-1.1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 154348
     checksum: sha256:40e39bd372ee233258f6c0b64ae62f5065d3c7bff91c891f2e0949b2ffa6e277
     name: glib-networking
     evr: 2.56.1-1.1.el8
     sourcerpm: glib-networking-2.56.1-1.1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/glibc-locale-source-2.28-251.el8_10.25.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 4418664
     checksum: sha256:6b4798b338d1daf94822feedd8f3a284920cc5527f3d7154cf21d17903b0ef35
     name: glibc-locale-source
     evr: 2.28-251.el8_10.25
     sourcerpm: glibc-2.28-251.el8_10.25.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/groff-base-1.22.3-18.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 1033924
     checksum: sha256:7fcc96203ab686368fb66f568d042c893a64ac965390fd73f5c891b8a553f430
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/g/gsettings-desktop-schemas-3.32.0-6.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 646900
     checksum: sha256:b978eeef8a94c6cd4be4aa90d3d9732864fbc6041aaa6fa2555e061db64777fb
     name: gsettings-desktop-schemas
     evr: 3.32.0-6.el8
     sourcerpm: gsettings-desktop-schemas-3.32.0-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/less-530-3.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 168392
     checksum: sha256:bb4fef8537a4bf6d932b1fbcae30614dd434656abbe40c76bbbf80a79fc76f7c
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 107352
     checksum: sha256:b0533fcad76e25a67ba0e44144a580757b4baf691cfdba14f8635fdeace3b6bf
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 101176
     checksum: sha256:9a2e49109984bfe36d34cc1815a6aee230a2d8bb3c13b03763a367216af34d67
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libgomp-8.5.0-28.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 208212
     checksum: sha256:5996e8b092fb720045220a5e2101b7dc61b7e852f7489ceabbafbc0b51844011
     name: libgomp
     evr: 8.5.0-28.el8_10
     sourcerpm: gcc-8.5.0-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libgusb-0.3.0-1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 48640
     checksum: sha256:c2117a3bd6fda1d527670af03819a353368f543a30f51ccf4e35ea96bd651c3c
     name: libgusb
     evr: 0.3.0-1.el8
     sourcerpm: libgusb-0.3.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libmodman-2.0.1-17.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 36072
     checksum: sha256:e2e79ae9c27bd89e089e1b31eea12084b0cce5aabdd7dd9113d9c8e53696d2ee
     name: libmodman
     evr: 2.0.1-17.el8
     sourcerpm: libmodman-2.0.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 34460
     checksum: sha256:baf0849b9de4c229b6e25d0c1f834bc6df96d49053c67d7eef95f38fb71ebf52
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libpng-1.6.34-5.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 125024
     checksum: sha256:13eee378f386ece19fbd60558a2ed985eb5c32a076235c7ec15b49032888c828
     name: libpng
     evr: 2:1.6.34-5.el8
     sourcerpm: libpng-1.6.34-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libproxy-0.4.15-5.5.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 71496
     checksum: sha256:2d1dd72cefb8f119403628e8d32da0d48ca1fd1d043b8eea3dcd7902ae62e12c
     name: libproxy
     evr: 0.4.15-5.5.el8_10
     sourcerpm: libproxy-0.4.15-5.5.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libsoup-2.62.3-9.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
-    size: 423680
-    checksum: sha256:ca134f0d84397984b7f4e48b8c5776918265a3674ae9ef0a192945e64ac945d3
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libsoup-2.62.3-10.el8_10.s390x.rpm
+    repoid: ubi-8-for-s390x-baseos-rpms
+    size: 422924
+    checksum: sha256:915308405cbd7f4a1636a9d9de5cd1536a611033b2a8ff1f479ec4663dc6f969
     name: libsoup
-    evr: 2.62.3-9.el8_10
-    sourcerpm: libsoup-2.62.3-9.el8_10.src.rpm
+    evr: 2.62.3-10.el8_10
+    sourcerpm: libsoup-2.62.3-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/libxslt-1.1.32-6.3.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 242820
     checksum: sha256:8e78f0147edbbbe5b763674bcbff47051cbc3a40a9159edc3b0d84f7099a73fd
     name: libxslt
     evr: 1.1.32-6.3.el8_10
     sourcerpm: libxslt-1.1.32-6.3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/l/lksctp-tools-1.0.18-3.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 97884
     checksum: sha256:77b0eaf9e97b51efb226502b04500e94a05bce8ca1450d731ebf0f2d2572633d
     name: lksctp-tools
     evr: 1.0.18-3.el8
     sourcerpm: lksctp-tools-1.0.18-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 393524
     checksum: sha256:e81f127a0b60b267e8bbded5ce8ce5f9f2746020a3b07cd96b9d9bde8e080318
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/o/openssh-8.0p1-26.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 524336
     checksum: sha256:ba3d00e669aff2209202b28171257e6188c061fd3da01d2855599acd8a9d7633
     name: openssh
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/o/openssh-clients-8.0p1-26.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 708680
     checksum: sha256:e1c82a2e3e6fcde0710edc1186e8332a534b5589dce979397b31dbbfe0d33ed2
     name: openssh-clients
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 58424
     checksum: sha256:684d8438fec907d780ad69dd6f7571f84d73fecefc66026b751935d463973bd8
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Encode-2.97-3.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 1536596
     checksum: sha256:d2c97f8d96d6f82e34975bfcf8c25606e0370a3def4da27d6aabc85a86f589ca
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Errno-1.28-423.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 78552
     checksum: sha256:f60c79489fb824b5101c5108256d9e6a6378869d4b2f72de951de83d6b61cc2e
     name: perl-Errno
     evr: 1.28-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-IO-1.38-423.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 145612
     checksum: sha256:44ed6f3703f3d9bd247f616f9a32d9a4eb14e3d2cccc0bd4a785a2d18a18be47
     name: perl-IO
     evr: 1.38-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 31084
     checksum: sha256:01273ffc5443535d055b7962e173a10028fd2f128124480f587f8f9d7f4d4688
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 91960
     checksum: sha256:05bd495695df8a78448ff0d2f2df0480f0bc49c9b7065bc2b1ceba41b42f1772
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 67760
     checksum: sha256:475a66955c1749ba4ea13b5f4935dd13ac322c516961a512386496fe45d04472
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Socket-2.027-3.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 59120
     checksum: sha256:9ee041eadd639ab6d9187f164c7f7b7954bdb4bf5f228555176207528e84fb1f
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Storable-3.11-3.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 94936
     checksum: sha256:d6a82133f2ab89874788c141b10ed1f090689cd823a7559ed9197403f4000506
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 87108
     checksum: sha256:7c37700693bc781506a06eafc18ab1cb4a7f6b7559f0595c97f60a4f88390233
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-interpreter-5.26.3-423.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 6608148
     checksum: sha256:c14e38b17676af74e832879344569d3a3de70db88ab2093f1729ed1ec0059341
     name: perl-interpreter
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-libs-5.26.3-423.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 1559160
     checksum: sha256:b94bccb30f7dc32b0f357085d9650f07bf9c2105f83155ec777f2110c79c4125
     name: perl-libs
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-macros-5.26.3-423.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 74456
     checksum: sha256:484ae21f5266c2a7dbabf89ea40744142e5924fecf0569db7712f46f2a1b8bae
     name: perl-macros
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-threads-2.21-2.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 61484
     checksum: sha256:fdbce603c9cb7792728413638e4d5591f0d094a361e07ff4fe0b7014a61b0104
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 47772
     checksum: sha256:2cd240f59d6570295931d54dfb392604f524572cfe252b1b1c8cec7793736e4d
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 38456
     checksum: sha256:dfc66ad26e3a0462454c38d08c96f40d7a9bd5b4a54befc84d9b160411389d7a
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 15640
     checksum: sha256:b6085bdc7a6ac3df0bb71a11b789ff5ce8475ba0dadd5bceae97ec98d1aec5c8
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/u/unzip-6.0-48.el8_10.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 191820
     checksum: sha256:5a98f1ca41464eb0ca001a6347b88a51d6427b52fd5686a09bee57d52e18d913
     name: unzip
     evr: 6.0-48.el8_10
     sourcerpm: unzip-6.0-48.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/baseos/os/Packages/z/zip-3.0-23.el8.s390x.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-s390x-baseos-rpms
     size: 272640
     checksum: sha256:530b0386791c2af85a0c71aba024882b33f0e62a7c4ca53fa1cd75f5de384061
     name: zip
@@ -3298,1099 +3298,1099 @@ arches:
     sourcerpm: zip-3.0-23.el8.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/repodata/ba775bf0d1c58ed444736628d96a5798ee28260c42ba4796ae904858ae9993a8-modules.yaml.gz
-    repoid: ubi-8-appstream
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/s390x/appstream/os/repodata/654e4903cdcd9eb2551dbe80232d51e9f31d00a869329c4ede3f351deddf1a05-modules.yaml.gz
+    repoid: ubi-8-for-s390x-appstream-rpms
     size: 56989
-    checksum: sha256:ba775bf0d1c58ed444736628d96a5798ee28260c42ba4796ae904858ae9993a8
+    checksum: sha256:654e4903cdcd9eb2551dbe80232d51e9f31d00a869329c4ede3f351deddf1a05
 - arch: x86_64
   packages:
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/abattis-cantarell-fonts-0.0.25-6.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 159316
     checksum: sha256:2829ee7cd506bfadd391e04c6281fec277f2681e6b360bdbfc0305c48d429c3c
     name: abattis-cantarell-fonts
     evr: 0.0.25-6.el8
     sourcerpm: abattis-cantarell-fonts-0.0.25-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/adwaita-cursor-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 662496
     checksum: sha256:1672a332f0108712757853e99e63fc9f659fe14cfc3d36b6e36ce07c564ef05a
     name: adwaita-cursor-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/adwaita-icon-theme-3.28.0-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 11982852
     checksum: sha256:99cf2d2181327417b07c83fd999749774046330f5ca24991d3eb4d967aed6bae
     name: adwaita-icon-theme
     evr: 3.28.0-3.el8
     sourcerpm: adwaita-icon-theme-3.28.0-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/alsa-lib-1.2.10-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 513328
     checksum: sha256:bdd917892337077cec5f22e2727203df0bec23868a44153e34a12dce282d02ce
     name: alsa-lib
     evr: 1.2.10-2.el8
     sourcerpm: alsa-lib-1.2.10-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/at-spi2-atk-2.26.2-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 91488
     checksum: sha256:db3f68f7b4b08638dad4a7a24f288fa480f6bb8548f0a9ac29d2c43ea541a83f
     name: at-spi2-atk
     evr: 2.26.2-1.el8
     sourcerpm: at-spi2-atk-2.26.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/at-spi2-core-2.28.0-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 173356
     checksum: sha256:a491041cdee37b4f1ebc31ea261f9fda268182d64c51b05a4710db1fcbbf38b7
     name: at-spi2-core
     evr: 2.28.0-1.el8
     sourcerpm: at-spi2-core-2.28.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/a/atk-2.28.1-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 278108
     checksum: sha256:5072ec9c8d2d33c8b897cf436040c566d70ac3aa65fe67975992e765fca10e80
     name: atk
     evr: 2.28.1-1.el8
     sourcerpm: atk-2.28.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/c/cairo-1.15.12-6.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 735920
     checksum: sha256:8395c703800c9261454792650649c7df35a6af34b8f254fc4e0bf4c0459d2aa7
     name: cairo
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/c/cairo-gobject-1.15.12-6.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 34252
     checksum: sha256:7b0a4aaf29e6356bda96e34cf5e2a758975c49eea31d1843e8992e850d40ad0f
     name: cairo-gobject
     evr: 1.15.12-6.el8
     sourcerpm: cairo-1.15.12-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/c/colord-libs-1.4.2-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 241520
     checksum: sha256:eda5ee783fd4f3cbbf183b9650a4c9553cb93d8aec2f0ec8c06d1209fad57808
     name: colord-libs
     evr: 1.4.2-1.el8
     sourcerpm: colord-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/c/copy-jdk-configs-4.0-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 31276
     checksum: sha256:5520be18012994682dd26352095e9ddea7d63e95c557cb411048a721cd6322c8
     name: copy-jdk-configs
     evr: 4.0-2.el8
     sourcerpm: copy-jdk-configs-4.0-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/d/dconf-0.28.0-4.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 110996
     checksum: sha256:2f087a9ec0def232acb6c3a922bdf24a6b0c41770ec870c81f8e454162d4b737
     name: dconf
     evr: 0.28.0-4.el8
     sourcerpm: dconf-0.28.0-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/f/fribidi-1.0.4-9.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 91588
     checksum: sha256:576f8635aba31c4b3a54d99ddc918b0d74cff18c6f6125d341607f80618c9d9a
     name: fribidi
     evr: 1.0.4-9.el8
     sourcerpm: fribidi-1.0.4-9.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/gdk-pixbuf2-modules-2.36.12-7.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 111672
     checksum: sha256:21b53a48c6c21a29f43e0ee92d6c9b8b1bf4110045b4619862c0e7ff20d20102
     name: gdk-pixbuf2-modules
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/git-2.43.7-1.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 94884
     checksum: sha256:c9c97b1e34949a29e3ef951f9f91d583cc6e5859cd3028995ac3095b2f5051db
     name: git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/git-core-2.43.7-1.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 11631124
     checksum: sha256:51124ac7ed4c97b5a62a34a3b5e6139a3012d8fd516d3d56bc83490b19aa6bc9
     name: git-core
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/git-core-doc-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 3216756
     checksum: sha256:09202aba03724180992d4cb6a3c617423ee25dc61f2c162990a25d7781977058
     name: git-core-doc
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/git-lfs-3.4.1-5.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 4708148
     checksum: sha256:48a33549f1c0775678d34dc95eba7d88ffc7e4c036f2ab1778d96f83dc29373d
     name: git-lfs
     evr: 3.4.1-5.el8_10
     sourcerpm: git-lfs-3.4.1-5.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/graphite2-1.3.10-10.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 124536
     checksum: sha256:2917eaeca5b9b33ab21feb85ed331e0d09704e0930d70c04ca50883a97e4a61f
     name: graphite2
     evr: 1.3.10-10.el8
     sourcerpm: graphite2-1.3.10-10.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/gtk-update-icon-cache-3.22.30-12.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 33096
     checksum: sha256:a95186b16a53a4706f3a84476a9f0ab547c2f36f99fa1a9b1fa66455b14c426a
     name: gtk-update-icon-cache
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/g/gtk3-3.22.30-12.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 4696708
     checksum: sha256:3d4cc337c3fe7aaffa05c1e17c3c2a8e5cf80e13503a9def67e47d299b6a711c
     name: gtk3
     evr: 3.22.30-12.el8_10
     sourcerpm: gtk3-3.22.30-12.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/h/harfbuzz-1.7.5-4.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 302876
     checksum: sha256:90a04d6a0c81f6d7f311a7dccba1b0d146f5db315e49d304f76f4e2fc768e0c2
     name: harfbuzz
     evr: 1.7.5-4.el8
     sourcerpm: harfbuzz-1.7.5-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/h/hicolor-icon-theme-0.17-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 49600
     checksum: sha256:66bab4d22c2d9f29dc7c7651afa44456e306c6c9c175f96f5021b1887d9a5796
     name: hicolor-icon-theme
     evr: 0.17-2.el8
     sourcerpm: hicolor-icon-theme-0.17-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/jasper-libs-2.0.14-6.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 170656
     checksum: sha256:712c2679d8acc76f2d7492dc2fc796ba5b409026f4b95d4fb85bebc52981c445
     name: jasper-libs
     evr: 2.0.14-6.el8_10
     sourcerpm: jasper-2.0.14-6.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-17.0.16.0.8-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 504952
-    checksum: sha256:11d856b6573ec1e77b4e526e13ddd78c8ad1793a777a4402b6aca59a97f07889
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-17.0.17.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 511104
+    checksum: sha256:d9f0aab0df2de38f1a8b086c9baf2d0829c2d311f54c8c24eb06ed90e3be948a
     name: java-17-openjdk
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-devel-17.0.16.0.8-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 5370792
-    checksum: sha256:bca6c64e4c82018c611a89ad22976c018f46c69cdbc599f0ca4fe3663d993a17
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-devel-17.0.17.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 5370152
+    checksum: sha256:e773dceed35a041a19554ac4c8013306b33e544dc1ac913b2895c8c03537d7de
     name: java-17-openjdk-devel
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.16.0.8-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 48603128
-    checksum: sha256:dd3ea39046f524475f10634697b8e2786b64cd12da3295c1ed30c8e7cbe2518e
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-17-openjdk-headless-17.0.17.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 48653720
+    checksum: sha256:e90f772750e59f2d9908458badfc0347ad1e05b91dbaea861d0c8aea0c26c7ea
     name: java-17-openjdk-headless
-    evr: 1:17.0.16.0.8-2.el8
-    sourcerpm: java-17-openjdk-17.0.16.0.8-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-21.0.8.0.9-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 427668
-    checksum: sha256:a8a283005c923aa3710669fa131f31c4baec800b861750e73ccc988f263c0cc5
+    evr: 1:17.0.17.0.10-1.el8
+    sourcerpm: java-17-openjdk-17.0.17.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-21.0.9.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 402636
+    checksum: sha256:8a90b211ae6aa769752d28c8715e733da29a3e9f682af218dafdd51d348a213c
     name: java-21-openjdk
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-devel-21.0.8.0.9-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 5417392
-    checksum: sha256:9f9ffc9694ac4b0a135011db1540d842e4ce1c9f61462d4a964aa7956aa4dae7
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-devel-21.0.9.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 5417564
+    checksum: sha256:946c5abb7bd00f6aea96bd54416815055249a2b47878cdbdc88318bccb1786c5
     name: java-21-openjdk-devel
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-headless-21.0.8.0.9-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 52834652
-    checksum: sha256:3c6fcb08469cef41ec0052e12249ae3d29d79ffa5f1e5aed2431f4237d469782
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/java-21-openjdk-headless-21.0.9.0.10-1.el8.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 52881804
+    checksum: sha256:963572e2b2b3391dd118cd81c3061f62fba23026b9b736abd94bc62d1300bbde
     name: java-21-openjdk-headless
-    evr: 1:21.0.8.0.9-1.el8
-    sourcerpm: java-21-openjdk-21.0.8.0.9-1.el8.src.rpm
+    evr: 1:21.0.9.0.10-1.el8
+    sourcerpm: java-21-openjdk-21.0.9.0.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/javapackages-filesystem-5.3.0-1.module+el8+2447+6f56d9a6.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 31089
     checksum: sha256:0a2665447c6c2559229438b3cbb9b2a9c8d54886fc5cc9801d823d9991386a55
     name: javapackages-filesystem
     evr: 5.3.0-1.module+el8+2447+6f56d9a6
     sourcerpm: javapackages-tools-5.3.0-1.module+el8+2447+6f56d9a6.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/jbigkit-libs-2.1-14.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 55980
     checksum: sha256:5a55a840cccc45aef19b261cfff264420d28fcb31351b57da85d067fda73d7b7
     name: jbigkit-libs
     evr: 2.1-14.el8
     sourcerpm: jbigkit-2.1-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/j/jq-1.6-11.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 208552
     checksum: sha256:fe609ca5ea627f11fc4cd55cca0279f220f82e49045bfd59c38b560c82167662
     name: jq
     evr: 1.6-11.el8_10
     sourcerpm: jq-1.6-11.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/lcms2-2.9-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 168568
     checksum: sha256:7f2796df5a80f13ea11b3988175cc34cc2964d411480114c6c94671f054adf43
     name: lcms2
     evr: 2.9-2.el8
     sourcerpm: lcms2-2.9-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libX11-1.6.8-9.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 626860
     checksum: sha256:9c4012d2aaf2e9d1c5a7f315dd284b2df9380d40c2c928507de55585d3404ccf
     name: libX11
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libX11-common-1.6.8-9.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 162348
     checksum: sha256:558399ee08f1281a9e2eff4c0bbc3756d374d0e543587bcf2c12e557df479cc6
     name: libX11-common
     evr: 1.6.8-9.el8_10
     sourcerpm: libX11-1.6.8-9.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXau-1.0.9-3.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 38312
     checksum: sha256:a260f793e49805b188908e2f30c4687abe4e023b20c28a85d10d2371556c3981
     name: libXau
     evr: 1.0.9-3.el8
     sourcerpm: libXau-1.0.9-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXcomposite-0.4.4-14.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 29208
     checksum: sha256:731f537d1872b14290514b5a956c8c012a781f209a6a209ad9ba2cae1c56c388
     name: libXcomposite
     evr: 0.4.4-14.el8
     sourcerpm: libXcomposite-0.4.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXcursor-1.1.15-3.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 36728
     checksum: sha256:f75e90c48ab7c823d22717c4c28324a2add144a230f1298486715cff1cf0152b
     name: libXcursor
     evr: 1.1.15-3.el8
     sourcerpm: libXcursor-1.1.15-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXdamage-1.1.4-14.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 27352
     checksum: sha256:2da144f494567dea106daaa85ac1bc4aed74dbd0eb9224d74209930c468c8649
     name: libXdamage
     evr: 1.1.4-14.el8
     sourcerpm: libXdamage-1.1.4-14.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXext-1.3.4-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 46516
     checksum: sha256:ddafccd3f010fc75da6de158b5a68fd672f8b3554ac403065490318ce2be05f3
     name: libXext
     evr: 1.3.4-1.el8
     sourcerpm: libXext-1.3.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXfixes-5.0.3-7.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 25536
     checksum: sha256:42cd48bff06dee66716b6a6362d6469168d4657511fcf3bd16003c441dc88fea
     name: libXfixes
     evr: 5.0.3-7.el8
     sourcerpm: libXfixes-5.0.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXft-2.3.3-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 68352
     checksum: sha256:9b079ce20a6524d8e85d139b2ec2a7dd3f4f79fa283f68208b72b8091e6bde3b
     name: libXft
     evr: 2.3.3-1.el8
     sourcerpm: libXft-2.3.3-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXi-1.7.10-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 49876
     checksum: sha256:efc45d8d4a0227c6f104cc45622b2251b198dd830aeb1cacd5c47dcd67da7186
     name: libXi
     evr: 1.7.10-1.el8
     sourcerpm: libXi-1.7.10-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXinerama-1.1.4-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 15936
     checksum: sha256:9226efc49ff191d0d713446e8b28bb58ae4ab1cb64e34a6f7fc08af247202cdd
     name: libXinerama
     evr: 1.1.4-1.el8
     sourcerpm: libXinerama-1.1.4-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXrandr-1.5.2-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 34436
     checksum: sha256:34b08ea266a4bbddffe8307693742c11a09c3dc2a9f271f95a7ab5c4f67ea3e3
     name: libXrandr
     evr: 1.5.2-1.el8
     sourcerpm: libXrandr-1.5.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXrender-0.9.10-7.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 33568
     checksum: sha256:871672b8a9ffbe887b32e736494c1f005795bc7ffda026c6a063ee0d28788709
     name: libXrender
     evr: 0.9.10-7.el8
     sourcerpm: libXrender-0.9.10-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libXtst-1.2.3-7.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 22244
     checksum: sha256:5b245bf383bccc194e13f9f328a1a374f6ac39becd1c8756a18654575e258687
     name: libXtst
     evr: 1.2.3-7.el8
     sourcerpm: libXtst-1.2.3-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libdatrie-0.2.9-7.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 33932
     checksum: sha256:95d7e5810a279383b792dcc0656b539ffdce847b2b51730ee45f1af46fe994d4
     name: libdatrie
     evr: 0.2.9-7.el8
     sourcerpm: libdatrie-0.2.9-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libepoxy-1.5.8-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 230280
     checksum: sha256:7166f018ce9bfd0625f9e992bd5f4316bd4f7c51a0797b9ebd736d62c6bf0385
     name: libepoxy
     evr: 1.5.8-1.el8
     sourcerpm: libepoxy-1.5.8-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libfontenc-1.1.3-8.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 37636
     checksum: sha256:5b2545c178e52a79fd09414db8788d4c9f96b48f6e4d568c762e70b56b4858e8
     name: libfontenc
     evr: 1.1.3-8.el8
     sourcerpm: libfontenc-1.1.3-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libjpeg-turbo-1.5.3-14.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 161200
     checksum: sha256:05500f57a962d58103e2fe1311fb6d08b3ee129355bde0da702a7e62a7316da6
     name: libjpeg-turbo
     evr: 1.5.3-14.el8_10
     sourcerpm: libjpeg-turbo-1.5.3-14.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libthai-0.1.27-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 207716
     checksum: sha256:3d203f221eb11b5a0a216427dee391294b0fb3aa0bc3348fd0d4330556a9b011
     name: libthai
     evr: 0.1.27-2.el8
     sourcerpm: libthai-0.1.27-2.el8.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libtiff-4.0.9-34.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
-    size: 195016
-    checksum: sha256:41c5d53c967c3d58f3c564f8dab320061461779c9c3350e6708d4003a950aeb7
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libtiff-4.0.9-35.el8_10.x86_64.rpm
+    repoid: ubi-8-for-x86_64-appstream-rpms
+    size: 194176
+    checksum: sha256:50af733a2f9aaaf1c0d45276bd8f178a1cd4127d602a78b15f3cd7dc7c576518
     name: libtiff
-    evr: 4.0.9-34.el8_10
-    sourcerpm: libtiff-4.0.9-34.el8_10.src.rpm
+    evr: 4.0.9-35.el8_10
+    sourcerpm: libtiff-4.0.9-35.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libwayland-client-1.21.0-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 41660
     checksum: sha256:f79cef9a39104aa6447efaedd3e6fc702014cd4a5a543932c7c1c9897253818f
     name: libwayland-client
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libwayland-cursor-1.21.0-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 26508
     checksum: sha256:0ef42f8bbfcf20327b91b69eda9fea7d3b4aae79bb19ab1363b2e1d6840377f7
     name: libwayland-cursor
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libwayland-egl-1.21.0-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 20016
     checksum: sha256:106ead5fe1e641f86d45cd77b154d31393e5e3d43a342f52d4a1f5a9bdca9444
     name: libwayland-egl
     evr: 1.21.0-1.el8
     sourcerpm: wayland-1.21.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/libxcb-1.13.1-1.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 234420
     checksum: sha256:39e6bc1e8101e536066554702d5d6b25f8cad359fb5e02ac598cfdad56eafb6d
     name: libxcb
     evr: 1.13.1-1.el8
     sourcerpm: libxcb-1.13.1-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/l/lua-5.3.4-12.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 196992
     checksum: sha256:31f8fbc1504f93090f0eaf548e5d7e05d668133459d60b32d45170767df01558
     name: lua
     evr: 5.3.4-12.el8
     sourcerpm: lua-5.3.4-12.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nspr-4.36.0-2.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 146684
     checksum: sha256:a1586a50729b7026ea958d2ed8e3f138e7b7c0551ff43305875f906638ce3985
     name: nspr
     evr: 4.36.0-2.el8_10
     sourcerpm: nspr-4.36.0-2.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nss-3.112.0-4.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 789520
     checksum: sha256:9884f27539ca7ad472d5d100d822c843b8dbce2814c5450837c6cff0de9eceb7
     name: nss
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nss-softokn-3.112.0-4.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 553320
     checksum: sha256:059b51ad2de84786aa5e9cbd9117e28229e4cf7ed796b7cb344a5ec72261e14e
     name: nss-softokn
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nss-softokn-freebl-3.112.0-4.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 493156
     checksum: sha256:d9e5071f99915794bc44a03a1202fb46337d39e302c7ff5809bebea06b41ece6
     name: nss-softokn-freebl
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nss-sysinit-3.112.0-4.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 77972
     checksum: sha256:2249130b1f0e0acea2d7e903590a588d3536d3314ed6590e4c5fc6bdc3f7f0b8
     name: nss-sysinit
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/n/nss-util-3.112.0-4.el8_10.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 145932
     checksum: sha256:69de56386f7a0f1da15c8396bbdeb7d921a8ce880233f1f07ca82a23ab1947c5
     name: nss-util
     evr: 3.112.0-4.el8_10
     sourcerpm: nss-3.112.0-4.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/o/oniguruma-6.8.2-3.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 192632
     checksum: sha256:1c5c91d8a33987892ec7320c08311a31245be91800aa5879e20d137971bd053f
     name: oniguruma
     evr: 6.8.2-3.el8
     sourcerpm: oniguruma-6.8.2-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/pango-1.42.4-8.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 304480
     checksum: sha256:d0e41cd47e15807906792aaff4ebc2502efc63548e09da456b105748129d09b9
     name: pango
     evr: 1.42.4-8.el8
     sourcerpm: pango-1.42.4-8.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Digest-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 27624
     checksum: sha256:9e90e6054da06f5c8c2733c3b66987693a58ddc1f05d95b23ca0a464e26a2b22
     name: perl-Digest
     evr: 1.17-395.el8
     sourcerpm: perl-Digest-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Digest-MD5-2.55-396.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 37880
     checksum: sha256:83ffd804a5c0ac401ea30620a563a57bbfd2eb1f16cbc6813b7ea22303ac9f53
     name: perl-Digest-MD5
     evr: 2.55-396.el8
     sourcerpm: perl-Digest-MD5-2.55-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Error-0.17025-2.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 47160
     checksum: sha256:a6ba7653293a529eddb0245935f26091e2fef58e1d479297056e78a4424acd92
     name: perl-Error
     evr: 1:0.17025-2.el8
     sourcerpm: perl-Error-0.17025-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Git-2.43.7-1.el8_10.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 81136
     checksum: sha256:cc2b622933dabf0579711ce3fdccfd5b485483b8b0f8ed4dc2df3d59842ba735
     name: perl-Git
     evr: 2.43.7-1.el8_10
     sourcerpm: git-2.43.7-1.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-IO-Socket-IP-0.39-5.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 47972
     checksum: sha256:7519f2af362827daecf105e1dccb551350f32dfd3f6a8a85bf6eb1b4b7788255
     name: perl-IO-Socket-IP
     evr: 0.39-5.el8
     sourcerpm: perl-IO-Socket-IP-0.39-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 304826
     checksum: sha256:e82ab03c8a19f40df7f1eee34786246562ba4f5d5876ce77736ecde219006cf4
     name: perl-IO-Socket-SSL
     evr: 2.066-4.module+el8.3.0+6446+594cad75
     sourcerpm: perl-IO-Socket-SSL-2.066-4.module+el8.3.0+6446+594cad75.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 15771
     checksum: sha256:d2593772ce32d37483f61d254990c31e3548ab504c793b95e8f4603a5040032b
     name: perl-Mozilla-CA
     evr: 20160104-7.module+el8.3.0+6498+9eecfe51
     sourcerpm: perl-Mozilla-CA-20160104-7.module+el8.3.0+6498+9eecfe51.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 388290
     checksum: sha256:290312d4dd2d24f0c42235a50512d5a7d23018a0ef12eb54907aa8f88cc22fb3
     name: perl-Net-SSLeay
     evr: 1.88-2.module+el8.6.0+13392+f0897f98
     sourcerpm: perl-Net-SSLeay-1.88-2.module+el8.6.0+13392+f0897f98.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-TermReadKey-2.37-7.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 41200
     checksum: sha256:ea22b60430f762e2b8e2d5697522af1aa937ea0b933c6dbe5b5a8ca4f2b7dbd6
     name: perl-TermReadKey
     evr: 2.37-7.el8
     sourcerpm: perl-TermReadKey-2.37-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-URI-1.73-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 118948
     checksum: sha256:dd6a948e5a656701156c618e202c0b6defd11ba6f162b6790cbb42cea15141ae
     name: perl-URI
     evr: 1.73-3.el8
     sourcerpm: perl-URI-1.73-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/perl-libnet-3.11-3.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 123808
     checksum: sha256:81afd309f084c91d68c06bd46a4fce2e0d1e265a01ff87e309d1202e711e4a02
     name: perl-libnet
     evr: 3.11-3.el8
     sourcerpm: perl-libnet-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/p/pixman-0.38.4-4.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 263800
     checksum: sha256:7b463191aeedc6c0dde44a0196c708cade83c24d643829e50e0656e8383f78ae
     name: pixman
     evr: 0.38.4-4.el8
     sourcerpm: pixman-0.38.4-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/r/rest-0.8.1-2.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 72200
     checksum: sha256:65f09851bd80394b34b388d3df5bc6955bfa7e5a9a525bebe915e5adf9052780
     name: rest
     evr: 0.8.1-2.el8
     sourcerpm: rest-0.8.1-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/t/ttmkfdir-3.0.9-54.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 63008
     checksum: sha256:9fa5c302015e9b059411358c7844d177449de258f97b228ee95a321af8d2ddf0
     name: ttmkfdir
     evr: 3.0.9-54.el8
     sourcerpm: ttmkfdir-3.0.9-54.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/t/tzdata-java-2025b-1.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 191116
     checksum: sha256:3fa146aae879f61ff54642ba5b8b2922ef49b09c2a931ad4314b4137fd884175
     name: tzdata-java
     evr: 2025b-1.el8
     sourcerpm: tzdata-2025b-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/x/xmlstarlet-1.6.1-20.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 72316
     checksum: sha256:9eb27c74a46760d027dcb66eed2e7132ed805af98ca363553e050852b40b99ac
     name: xmlstarlet
     evr: 1.6.1-20.el8
     sourcerpm: xmlstarlet-1.6.1-20.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/x/xorg-x11-font-utils-7.5-41.el8.x86_64.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 106144
     checksum: sha256:966566770c97b65d5c2d743631322241fc8508f56c2698fc706bd7dba3761199
     name: xorg-x11-font-utils
     evr: 1:7.5-41.el8
     sourcerpm: xorg-x11-font-utils-7.5-41.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/Packages/x/xorg-x11-fonts-Type1-7.5-19.el8.noarch.rpm
-    repoid: ubi-8-appstream
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 534388
     checksum: sha256:c457303288fd423f9f320f3a05bc5a592455a75f14ea76db3a482633e59137ae
     name: xorg-x11-fonts-Type1
     evr: 7.5-19.el8
     sourcerpm: xorg-x11-fonts-7.5-19.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/a/avahi-libs-0.7-27.el8_10.1.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 63848
     checksum: sha256:f2f4b6a3501e339521c5e5f00e96fa06655535b564c24daa706a9064d543ae2c
     name: avahi-libs
     evr: 0.7-27.el8_10.1
     sourcerpm: avahi-0.7-27.el8_10.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/b/bc-1.07.1-5.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 131988
     checksum: sha256:f6e357fc61da8981294493b05c1d81014f4f56c6f2dc22544234fc311f5fcd61
     name: bc
     evr: 1.07.1-5.el8
     sourcerpm: bc-1.07.1-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/b/bzip2-1.0.6-28.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 61884
     checksum: sha256:917530892588f7815853b06bd6a8ed26137824f913be1949bd59a5090d673ab2
     name: bzip2
     evr: 1.0.6-28.el8_10
     sourcerpm: bzip2-1.0.6-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/c/cups-libs-2.2.6-63.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 446968
     checksum: sha256:24a4e0a44b9bf2e8d1a909c207b3e09b7c678e9146298b3750a049f36c1ad85f
     name: cups-libs
     evr: 1:2.2.6-63.el8_10
     sourcerpm: cups-2.2.6-63.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/d/dejavu-fonts-common-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 76096
     checksum: sha256:82f36244bf29111473619a3565e69d3e8213e829d8eaf3e141c6c397d574ccf3
     name: dejavu-fonts-common
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/d/dejavu-sans-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1558464
     checksum: sha256:488d2b14e88a91dfe40d5dbf9136f29b155d1fe22f6a6c442db528684cb55e95
     name: dejavu-sans-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/d/dejavu-sans-mono-fonts-2.35-7.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 457788
     checksum: sha256:bb4b2ae2789e9295d835c3c48705f5bd7f6813613f91faab19d4bcb37300b1c2
     name: dejavu-sans-mono-fonts
     evr: 2.35-7.el8
     sourcerpm: dejavu-fonts-2.35-7.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/e/emacs-filesystem-26.1-15.el8_10.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 72500
     checksum: sha256:3752a72be8d33b701a01e746dc2f8d56e2ba7829baa5f2bf3f1a590d8267c60a
     name: emacs-filesystem
     evr: 1:26.1-15.el8_10
     sourcerpm: emacs-26.1-15.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/f/fontconfig-2.13.1-4.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 280836
     checksum: sha256:7f2a8ed367bbe341e4c7570746cdeada3b68f6d1e498b411748b972190bce95c
     name: fontconfig
     evr: 2.13.1-4.el8
     sourcerpm: fontconfig-2.13.1-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/f/fontpackages-filesystem-1.44-22.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 16324
     checksum: sha256:db1fad3c2d8735e69084bd4b09ea963938e4dde2f2e096dc7a4ce146f18b7ab0
     name: fontpackages-filesystem
     evr: 1.44-22.el8
     sourcerpm: fontpackages-1.44-22.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/f/freetype-2.9.1-10.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 403276
     checksum: sha256:2ef3b0f9975f2c7d9f3ca3d336efa90cffdb8101f594e7e0cf1a3b7efdb8f14e
     name: freetype
     evr: 2.9.1-10.el8_10
     sourcerpm: freetype-2.9.1-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/gdk-pixbuf2-2.36.12-7.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 477764
     checksum: sha256:da82fb06650a8afdebef603f0ac9a2adb2abb1bdbbaac5be544ac91f2250b5fc
     name: gdk-pixbuf2
     evr: 2.36.12-7.el8_10
     sourcerpm: gdk-pixbuf2-2.36.12-7.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/gettext-0.19.8.1-17.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1119284
     checksum: sha256:6ef0f876469f7c290b53362dd983a556edd6b5c8aace9d5e94c10bf27f0179bd
     name: gettext
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/gettext-libs-0.19.8.1-17.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 320224
     checksum: sha256:d31afc5532d581167003977d88771f22255923bf3a1aec4dabb5ac98ec910234
     name: gettext-libs
     evr: 0.19.8.1-17.el8
     sourcerpm: gettext-0.19.8.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/glib-networking-2.56.1-1.1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 158688
     checksum: sha256:c7e767d836fe8aef670eba2fde4f593996fbc0fb304a6666dcd53c0f9af7d184
     name: glib-networking
     evr: 2.56.1-1.1.el8
     sourcerpm: glib-networking-2.56.1-1.1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/glibc-locale-source-2.28-251.el8_10.25.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 4418696
     checksum: sha256:21db1770dd79aec538e82587af9955e7e992119effc4512a6e34a2e5dd95ac1a
     name: glibc-locale-source
     evr: 2.28-251.el8_10.25
     sourcerpm: glibc-2.28-251.el8_10.25.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/groff-base-1.22.3-18.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1069536
     checksum: sha256:73c29baa2cd94f1ae6a1d1333818969a281b16dd4262f413ad284c5333719a4d
     name: groff-base
     evr: 1.22.3-18.el8
     sourcerpm: groff-1.22.3-18.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/g/gsettings-desktop-schemas-3.32.0-6.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 648084
     checksum: sha256:a8d1cdd9a8852980390e1aee73365b5282f26551f40aeeb3339d19541d7d2054
     name: gsettings-desktop-schemas
     evr: 3.32.0-6.el8
     sourcerpm: gsettings-desktop-schemas-3.32.0-6.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/less-530-3.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 168216
     checksum: sha256:e459a0babd293f436fcf14d3ca98f2bcf18b40b0345aa97d9cf9813159a1f6d6
     name: less
     evr: 530-3.el8_10
     sourcerpm: less-530-3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libcroco-0.6.12-4.el8_2.1.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 115260
     checksum: sha256:d0982bac60512aaf37a99078e24446337ab6210db07ed95c49baeb9a3811dd2b
     name: libcroco
     evr: 0.6.12-4.el8_2.1
     sourcerpm: libcroco-0.6.12-4.el8_2.1.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libedit-3.1-23.20170329cvs.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 104512
     checksum: sha256:0391105afa53c9503b59591615bd7c98e2f7a4cd94ff4fd1451c4234522f3880
     name: libedit
     evr: 3.1-23.20170329cvs.el8
     sourcerpm: libedit-3.1-23.20170329cvs.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libgomp-8.5.0-28.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 213900
     checksum: sha256:1ec29eef5987da5a17e2f11dc7a5014e3b804801078ef67142ce6b4f06e93748
     name: libgomp
     evr: 8.5.0-28.el8_10
     sourcerpm: gcc-8.5.0-28.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libgusb-0.3.0-1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 50452
     checksum: sha256:305ec4b5026b8ecffdfdf253e24c96aba795e9d07d17d3cad2d9e5573b641728
     name: libgusb
     evr: 0.3.0-1.el8
     sourcerpm: libgusb-0.3.0-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libmodman-2.0.1-17.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 36984
     checksum: sha256:0602b342148d5e8e6a954bb26af60ed63d3f3d919cd3856ea93612e05ebe2937
     name: libmodman
     evr: 2.0.1-17.el8
     sourcerpm: libmodman-2.0.1-17.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libpkgconf-1.4.2-1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 35620
     checksum: sha256:96fadfed6a8225a89b331e7b62ed8ee74b393cea1520fa0d89f6f0dc1a458fb3
     name: libpkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libpng-1.6.34-5.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 129016
     checksum: sha256:53d9bb412615966acdf9a6b1c26c5899a9c2c0b76a27f360d3d6076536d2540a
     name: libpng
     evr: 2:1.6.34-5.el8
     sourcerpm: libpng-1.6.34-5.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libproxy-0.4.15-5.5.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 74928
     checksum: sha256:12e67370e5f1c1faffb3cef5de4688219de337fbf09ac812e4ea4a24b10eb8cd
     name: libproxy
     evr: 0.4.15-5.5.el8_10
     sourcerpm: libproxy-0.4.15-5.5.el8_10.src.rpm
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libsoup-2.62.3-9.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
-    size: 436576
-    checksum: sha256:10bd0222a54d329afa3727be621271ed49a74e23e766016b12ca231a9dc72e47
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libsoup-2.62.3-10.el8_10.x86_64.rpm
+    repoid: ubi-8-for-x86_64-baseos-rpms
+    size: 435708
+    checksum: sha256:41616064b8a44b93305d74356bce61ecdd9d8ad1ef1f4819f4ab991841785a40
     name: libsoup
-    evr: 2.62.3-9.el8_10
-    sourcerpm: libsoup-2.62.3-9.el8_10.src.rpm
+    evr: 2.62.3-10.el8_10
+    sourcerpm: libsoup-2.62.3-10.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libxslt-1.1.32-6.3.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 255324
     checksum: sha256:70de6a4040bed150cf2b34494e99b4645668d2c99854ff77d9e1edd6fe0cc0bf
     name: libxslt
     evr: 1.1.32-6.3.el8_10
     sourcerpm: libxslt-1.1.32-6.3.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/lksctp-tools-1.0.18-3.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 101924
     checksum: sha256:68fac30590576a29d6308beed508e68b5a4b2175f539b1812cab20e83e9136d8
     name: lksctp-tools
     evr: 1.0.18-3.el8
     sourcerpm: lksctp-tools-1.0.18-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/n/ncurses-6.1-10.20180224.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 396400
     checksum: sha256:998836898721566d3ff94e6d8babada71cc3635169c0763f4b53afabc5446fa1
     name: ncurses
     evr: 6.1-10.20180224.el8
     sourcerpm: ncurses-6.1-10.20180224.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/o/openssh-8.0p1-26.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 537472
     checksum: sha256:b489b3736df71503ca20b3f510e546f5d723bcb919994d54e8e8179956ca58ac
     name: openssh
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/o/openssh-clients-8.0p1-26.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 661048
     checksum: sha256:14bb4b83e3e8cb25945063c06c396058453f2273b4b9079606dfa3f9f517ea08
     name: openssh-clients
     evr: 8.0p1-26.el8_10
     sourcerpm: openssh-8.0p1-26.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Carp-1.42-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 30928
     checksum: sha256:77066ee655df356370b5d6d736d96835f5712f8e814dfc46b391ecaef9cdd19b
     name: perl-Carp
     evr: 1.42-396.el8
     sourcerpm: perl-Carp-1.42-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Data-Dumper-2.167-399.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 59400
     checksum: sha256:07820bf56fb684093cebe7f0be962785dd918e71082201eed45eae2cefc30669
     name: perl-Data-Dumper
     evr: 2.167-399.el8
     sourcerpm: perl-Data-Dumper-2.167-399.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Encode-2.97-3.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1545496
     checksum: sha256:5662a18ee7856572448295b688c12c2378a3f9fb830d1703da4c8491416b2586
     name: perl-Encode
     evr: 4:2.97-3.el8
     sourcerpm: perl-Encode-2.97-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Errno-1.28-423.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 78572
     checksum: sha256:1489ff9dac875ee8f6c929fe28b004912f6104ba9849603f3610d2d8e1b934ae
     name: perl-Errno
     evr: 1.28-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Exporter-5.72-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 34844
     checksum: sha256:7c385e32c12b2639232f74a5dfdfef86daf82e5418bc292c5ab2640fb5cf46dc
     name: perl-Exporter
     evr: 5.72-396.el8
     sourcerpm: perl-Exporter-5.72-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-File-Path-2.15-2.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 39036
     checksum: sha256:d906b13d5dd7a5595133e2a1af83ae17a1aae0c107579db723d21ec4371f3570
     name: perl-File-Path
     evr: 2.15-2.el8
     sourcerpm: perl-File-Path-2.15-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-File-Temp-0.230.600-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 64104
     checksum: sha256:537059f8a2598f7b364693aec72f67f1a954c525b381139f736d75edbf19aa12
     name: perl-File-Temp
     evr: 0.230.600-1.el8
     sourcerpm: perl-File-Temp-0.230.600-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Getopt-Long-2.50-4.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 64468
     checksum: sha256:2976f2c007ac981a70e414960cd7426f446ebc8a0bf8feae7a6ece06c63ffefb
     name: perl-Getopt-Long
     evr: 1:2.50-4.el8
     sourcerpm: perl-Getopt-Long-2.50-4.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-HTTP-Tiny-0.074-3.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 60116
     checksum: sha256:79e049eb0c62f528632082e1a3b9b25e2f686d5e6d3b6fed1ca2c33989b77c95
     name: perl-HTTP-Tiny
     evr: 0.074-3.el8
     sourcerpm: perl-HTTP-Tiny-0.074-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-IO-1.38-423.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 145948
     checksum: sha256:d5fc71a78e60651634d9efbfd4e5ad386aec77929ac855437ba0e1322d218763
     name: perl-IO
     evr: 1.38-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-MIME-Base64-3.15-396.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 31396
     checksum: sha256:78c75125187f1f8d66a6106ea7b07e8cf2b57c18bf85f6dd888842464b128a5c
     name: perl-MIME-Base64
     evr: 3.15-396.el8
     sourcerpm: perl-MIME-Base64-3.15-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-PathTools-3.74-1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 92196
     checksum: sha256:0e5d51dc3249aa800150bac70d394ad650dc509bebbec35446494f86cd92aecc
     name: perl-PathTools
     evr: 3.74-1.el8
     sourcerpm: perl-PathTools-3.74-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Pod-Escapes-1.07-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 20980
     checksum: sha256:21b1497d132a52c93129700d58c44ba8c36af8da1bbd23fb408c00c3117c1012
     name: perl-Pod-Escapes
     evr: 1:1.07-395.el8
     sourcerpm: perl-Pod-Escapes-1.07-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Pod-Perldoc-3.28-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 90248
     checksum: sha256:a660c78f704d3d22458c71d86605f51d62e3cc5306d22d66bb1df86c7274ad6c
     name: perl-Pod-Perldoc
     evr: 3.28-396.el8
     sourcerpm: perl-Pod-Perldoc-3.28-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Pod-Simple-3.35-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 218284
     checksum: sha256:e17077c8803f792c02570b2768510b8e4955bd0ae68ab4930e7060fcbb3793f6
     name: perl-Pod-Simple
     evr: 1:3.35-395.el8
     sourcerpm: perl-Pod-Simple-3.35-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Pod-Usage-1.69-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 35300
     checksum: sha256:f727e7919c662ae990d02ad2a6299ed3161ad7522587c11441477aae03549f06
     name: perl-Pod-Usage
     evr: 4:1.69-395.el8
     sourcerpm: perl-Pod-Usage-1.69-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Scalar-List-Utils-1.49-2.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 69428
     checksum: sha256:fbc4b08c066f448d213ba5acbcf20a8931c419d2238bc0fe5dd39f71bdf9b30d
     name: perl-Scalar-List-Utils
     evr: 3:1.49-2.el8
     sourcerpm: perl-Scalar-List-Utils-1.49-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Socket-2.027-3.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 60224
     checksum: sha256:cec7c0d124dc281ef4befe001bceabbeba83c5bf05c9a4430102b490cc8bf8e8
     name: perl-Socket
     evr: 4:2.027-3.el8
     sourcerpm: perl-Socket-2.027-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Storable-3.11-3.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 100672
     checksum: sha256:ceb9382fbfb2bda85764ea055ffdad26a202c5d8744d867472eb75020060a5aa
     name: perl-Storable
     evr: 1:3.11-3.el8
     sourcerpm: perl-Storable-3.11-3.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Term-ANSIColor-4.06-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 47120
     checksum: sha256:657efda777af4b0d63ab127a72f3373c0d8a18f3b81e912b24a5fbdc9927dc1e
     name: perl-Term-ANSIColor
     evr: 4.06-396.el8
     sourcerpm: perl-Term-ANSIColor-4.06-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Term-Cap-1.17-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 23368
     checksum: sha256:41c0f3ea7c7c2f21b5ccb0432db2c1b916ae34691a57f0b7bcb5a09dc7d8fafc
     name: perl-Term-Cap
     evr: 1.17-395.el8
     sourcerpm: perl-Term-Cap-1.17-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Text-ParseWords-3.30-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 18372
     checksum: sha256:25ff1ab94430493bde65da6a800bb2638edc64dca38971eba2c798475cc18b97
     name: perl-Text-ParseWords
     evr: 3.30-395.el8
     sourcerpm: perl-Text-ParseWords-3.30-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 24736
     checksum: sha256:7e078a375d2636b705e1734be79a8b76a306f8578066c901713663e367925bc7
     name: perl-Text-Tabs+Wrap
     evr: 2013.0523-395.el8
     sourcerpm: perl-Text-Tabs+Wrap-2013.0523-395.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Time-Local-1.280-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 34328
     checksum: sha256:4019e427bf69ed70e3a3cdfdcdd6771bcee1484f8e83bb69539a9e6530baddf1
     name: perl-Time-Local
     evr: 1:1.280-1.el8
     sourcerpm: perl-Time-Local-1.280-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-Unicode-Normalize-1.25-396.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 83844
     checksum: sha256:e2ad63f39d3e929d08f4938fb325a861bfa19715a3701dfceb06391d18ef3c42
     name: perl-Unicode-Normalize
     evr: 1.25-396.el8
     sourcerpm: perl-Unicode-Normalize-1.25-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-constant-1.33-396.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 25956
     checksum: sha256:36798d9e979c9976ed66e23b3c8bda6250c4e80e411afe55c3942291cb4cb4ce
     name: perl-constant
     evr: 1.33-396.el8
     sourcerpm: perl-constant-1.33-396.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-interpreter-5.26.3-423.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 6622556
     checksum: sha256:8505819ca7031e26a638e29f34e8808454a07c0828125976bdc0a3dda8291439
     name: perl-interpreter
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-libs-5.26.3-423.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 1633784
     checksum: sha256:34a52f691b8b1a740651589dda3643649fe54be9d1bb96337cd42b7361317b50
     name: perl-libs
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-macros-5.26.3-423.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 74476
     checksum: sha256:458d91cfbed0495cf14355c5901ad1f1c00a7e0a20bbe7efe1aa81ce130e0371
     name: perl-macros
     evr: 4:5.26.3-423.el8_10
     sourcerpm: perl-5.26.3-423.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-parent-0.237-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 20520
     checksum: sha256:abe578c5dee7c306812e241c77ebc8ba4b54f90df8e65c56f8f202ba6e0d7183
     name: perl-parent
     evr: 1:0.237-1.el8
     sourcerpm: perl-parent-0.237-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-podlators-4.11-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 120828
     checksum: sha256:4811ab95c1d50ef7380e2c5937ae4490f8e28f56cf787c189437d1709e4423fb
     name: perl-podlators
     evr: 4.11-1.el8
     sourcerpm: perl-podlators-4.11-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-threads-2.21-2.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 62692
     checksum: sha256:0d3f8e14265aa162bfcec4aff8064fa26188f1e51e897f20760bab906a9f9e5e
     name: perl-threads
     evr: 1:2.21-2.el8
     sourcerpm: perl-threads-2.21-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/perl-threads-shared-1.58-2.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 48800
     checksum: sha256:78af5e69d8a6b9dd041ec748e7401ed6f0ce80f2003f43a7723816d0b2aa4c69
     name: perl-threads-shared
     evr: 1.58-2.el8
     sourcerpm: perl-threads-shared-1.58-2.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/pkgconf-1.4.2-1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 38956
     checksum: sha256:b9d0a4c0e16db4c05b2d0690216d8c5da2db7d67bc765a00ce2a32c5f810c245
     name: pkgconf
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/pkgconf-m4-1.4.2-1.el8.noarch.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 17484
     checksum: sha256:9a89874a5b8326c85c0b34b02c122ffc052b32a12b20354ce95859ac5296a159
     name: pkgconf-m4
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.4.2-1.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 15628
     checksum: sha256:1c4a8674eafc31d36030f3fd0c081326d4301570d4e35b59d6f6ef1e163f655b
     name: pkgconf-pkg-config
     evr: 1.4.2-1.el8
     sourcerpm: pkgconf-1.4.2-1.el8.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/u/unzip-6.0-48.el8_10.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 200764
     checksum: sha256:f08307816a4aae5924ab3775c14a41124db9f8750d83bee2ecb93a29a3b5130a
     name: unzip
     evr: 6.0-48.el8_10
     sourcerpm: unzip-6.0-48.el8_10.src.rpm
   - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/z/zip-3.0-23.el8.x86_64.rpm
-    repoid: ubi-8-baseos
+    repoid: ubi-8-for-x86_64-baseos-rpms
     size: 276820
     checksum: sha256:da01d0096a9b85d229a8bd379f3d4e12656e5096573875f2b49b65652683a3c4
     name: zip
@@ -4398,7 +4398,7 @@ arches:
     sourcerpm: zip-3.0-23.el8.src.rpm
   source: []
   module_metadata:
-  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/repodata/15aad3221165af96b49d2aea94edb580c8ce58f28daa9459fdb68e419decb4fd-modules.yaml.gz
-    repoid: ubi-8-appstream
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/appstream/os/repodata/d50b1900a004ce441a6bc86d9301cd7d04250024493ee51304134fb0084cb9e2-modules.yaml.gz
+    repoid: ubi-8-for-x86_64-appstream-rpms
     size: 59092
-    checksum: sha256:15aad3221165af96b49d2aea94edb580c8ce58f28daa9459fdb68e419decb4fd
+    checksum: sha256:d50b1900a004ce441a6bc86d9301cd7d04250024493ee51304134fb0084cb9e2

--- a/tools/knflx-ecp-gen/main.go
+++ b/tools/knflx-ecp-gen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -58,6 +59,10 @@ func main() {
 				if err := t.Execute(os.Stdout, extract(d)); err != nil {
 					log.Fatalf("Failed to execute template: %v", err)
 				}
+				fmt.Fprintln(os.Stderr, "Use yq command to merge the exclusions:")
+				fmt.Fprintln(os.Stderr, "REPLACE=foo.yaml")
+				fmt.Fprintln(os.Stderr, "INPUT=bar.yaml")
+				fmt.Fprintln(os.Stderr, `yq eval ".spec.sources[0].volatileConfig = load(env(REPLACE)).volatileConfig" "$INPUT"`)
 				return
 			}
 		}
@@ -83,7 +88,7 @@ func extract(d interface{}) (r []string) {
 			}
 		case string:
 			for _, s := range re.FindAllStringSubmatch(x, -1) {
-				if len(s) > 1 && strings.HasPrefix(s[1], "sbom_spdx.allowed_package_sources:") {
+				if len(s) > 1 {
 					m[s[1]] = true
 				}
 			}
@@ -96,4 +101,3 @@ func extract(d interface{}) (r []string) {
 	sort.Strings(r)
 	return
 }
-

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,60 +1,60 @@
-[ubi-8-baseos]
+[ubi-8-for-$basearch-baseos-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-debug]
+[ubi-8-for-$basearch-baseos-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-baseos-source]
+[ubi-8-for-$basearch-baseos-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream]
+[ubi-8-for-$basearch-appstream-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-debug]
+[ubi-8-for-$basearch-appstream-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-appstream-source]
+[ubi-8-for-$basearch-appstream-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder]
+[codeready-builder-for-ubi-8-$basearch-rpms]
 name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
 enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-debug]
+[codeready-builder-for-ubi-8-$basearch-debug-rpms]
 name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
 enabled = 0
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 
-[ubi-8-codeready-builder-source]
+[codeready-builder-for-ubi-8-$basearch-source-rpms]
 name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
 baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
 enabled = 0


### PR DESCRIPTION
Use the ubi8 known rpm repositories from the below links:
https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/known_rpm_repositories.yml#L11603-L11626

Update Red Hat Konflux tekton tasks