### PR TITLE
NO-ISSUE: CVE-2026-21441: bump urllib3 to 2.6.3

### DIFF
--- a/smoke/requirements.txt
+++ b/smoke/requirements.txt
@@ -2,7 +2,7 @@ behave
 pyshould
 requests
 kubernetes
-urllib3
+urllib3==2.6.3
 pyfiglet
 clint
 python-jenkins


### PR DESCRIPTION
bump urllib3 to 2.6.3 to fix CVE-2026-21441