### PR TITLE
fix: Download jenkins-plugin-manager JAR in verify script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ kubeconfig
 __pycache__
 .kube
 .idea
+jenkins-plugin-manager.jar

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+set -euo pipefail
+
+PLUGIN_MANAGER_VERSION="2.14.0"
+PLUGIN_MANAGER_JAR="2/contrib/openshift/jenkins-plugin-manager.jar"
+PLUGIN_MANAGER_URL="https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_MANAGER_VERSION}/jenkins-plugin-manager-${PLUGIN_MANAGER_VERSION}.jar"
+
+if [ ! -f "$PLUGIN_MANAGER_JAR" ]; then
+  printf "Downloading jenkins-plugin-manager %s ...\n" "$PLUGIN_MANAGER_VERSION"
+  curl -sSfL -o "$PLUGIN_MANAGER_JAR" "$PLUGIN_MANAGER_URL"
+fi
+
+PLUGIN_DIR=$(mktemp -d)
+trap 'rm -rf "$PLUGIN_DIR"' EXIT
 
 printf "Checking for plugin vulnerabilities in 2/contrib/openshift/bundle-plugins.txt\n"
-java -jar 2/contrib/openshift/jenkins-plugin-manager.jar --view-security-warnings --plugin-file 2/contrib/openshift/bundle-plugins.txt --jenkins-version $(cat 2/contrib/openshift/jenkins-version.txt)
+java -jar "$PLUGIN_MANAGER_JAR" --view-security-warnings -d "$PLUGIN_DIR" --plugin-file 2/contrib/openshift/bundle-plugins.txt --jenkins-version "$(cat 2/contrib/openshift/jenkins-version.txt)"


### PR DESCRIPTION
verify.sh assumed jenkins-plugin-manager.jar existed locally but it was never included in the repo. The script now downloads the JAR from GitHub releases on first run, uses a temp plugin directory so it works outside the container image, and gitignores the downloaded binary.

tool - https://github.com/jenkinsci/plugin-installation-manager-tool