### PR TITLE
JKNS-1055: sync master with release-rhel9

### DIFF
--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -18,7 +18,7 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == false ]]; then
         echo "jenkins.war already exists, skipping upstream RPM installation"
     else
         echo "Installing jenkins.war from upstream RPM"
-        curl https://pkg.jenkins.io/rpm-stable/jenkins.repo | tee /etc/yum.repos.d/jenkins.repo /etc/yum.repos.art/ci/jenkins.repo
+        curl https://pkg.jenkins.io/rpm-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key
@@ -30,9 +30,12 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == false ]]; then
     
     /usr/local/bin/install-plugins.sh $PLUGIN_LIST
 else
-    yum install -y --disableplugin=subscription-manager jenkins-2.* jenkins-2-plugins
-    rpm -V jenkins-2.* jenkins-2-plugins
-    yum clean all
+    # Konflux build copies the /usr/lib/jenkins/plugins/*.hpi from the cachi2;
+    # Hence commenting the RPM installation commands
+    # yum install -y --disableplugin=subscription-manager jenkins-2.* jenkins-2-plugins
+    # rpm -V jenkins-2.* jenkins-2-plugins
+    # yum clean all
+
     # Remove the base-plugins.txt file because it's only used for Centos
     # and its presence in the rhel image is confusing.
     rm /opt/openshift/base-plugins.txt

--- a/scripts/verify-jenkins.sh
+++ b/scripts/verify-jenkins.sh
@@ -221,11 +221,11 @@ check_failed_log() {
 }
 
 verify_installed_packages() {
-	http_status_code=$(curl -s -o "/tmp/Dockerfile.rhel8" -w "%{http_code}\n" "${GITHUB_JENKINS_BASE_URL}/${SHA}/2/Dockerfile.rhel8" 2> /dev/null)
+	http_status_code=$(curl -s -o "/tmp/Dockerfile.rhel9" -w "%{http_code}\n" "${GITHUB_JENKINS_BASE_URL}/${SHA}/2/Dockerfile.rhel9" 2> /dev/null)
 	printf "[VERIFYING] Installed packages ...\n"
 
 	# Download the remote file to a temporary file, verifying the http_status code for the request
-	printf "\t%-50s" "- downloading Dockerfile.rhel8 ... "
+	printf "\t%-50s" "- downloading Dockerfile.rhel9 ... "
 	if [ "$http_status_code" == 200 ]; then
 		printf "PASS\n"
 	else
@@ -233,7 +233,7 @@ verify_installed_packages() {
 		printf "failed to download %s, http status code: %s" "${remote_file_path}" "${http_status_code}" >> $FAILED_LOG_LOCATION
 	fi
 
-	 INSTALL_PKGS=$(grep "INSTALL_PKGS=" /tmp/Dockerfile.rhel8)
+	 INSTALL_PKGS=$(grep "INSTALL_PKGS=" /tmp/Dockerfile.rhel9)
 	 INSTALL_PKGS=${INSTALL_PKGS//INSTALL_PKGS=\"/}
 	 INSTALL_PKGS=${INSTALL_PKGS//\" && \\/}
 	 INSTALL_PKGS=$(echo "${INSTALL_PKGS}" | xargs)

--- a/slave-base/Dockerfile.rhel9
+++ b/slave-base/Dockerfile.rhel9
@@ -1,31 +1,48 @@
 ##############################################
 # Stage 1 : Build go-init
 ##############################################
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS go-init-builder
+FROM registry.redhat.io/ubi9/go-toolset:1.21 AS go-init-builder
 WORKDIR  /go/src/github.com/openshift/jenkins
 COPY . .
 WORKDIR  /go/src/github.com/openshift/jenkins/go-init
-RUN GO111MODULE=off go build . && cp go-init /usr/bin
+RUN GO111MODULE=off go build -o /usr/bin/go-init .
 
 ##############################################
 # Stage 2 : Build slave-base with go-init
 ##############################################
-FROM registry.ci.openshift.org/ocp/4.16:cli
+FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.21
+ARG CI_UPSTREAM_COMMIT \
+    CI_UPSTREAM_URL \
+    OCP_VERSION
 COPY --from=go-init-builder /usr/bin/go-init /usr/bin/go-init
 
 # Labels consumed by Red Hat build service
-LABEL com.redhat.component="jenkins-slave-base-rhel9-container" \
-    name="openshift4/jenkins-slave-base-rhel9" \
+LABEL com.redhat.component="jenkins-agent-base-rhel9-container" \
+    name="ocp-tools-4/jenkins-agent-base-rhel9" \
+    description="The jenkins agent base image is intended to be built on top of, to add your own tools that your jenkins job needs. The agent base image includes all the jenkins logic to operate as a agent, so users just have to yum install any additional packages their specific jenkins job will need" \
     architecture="x86_64" \
-    io.k8s.display-name="Jenkins Slave Base" \
-    io.k8s.description="The jenkins slave base image is intended to be built on top of, to add your own tools that your jenkins job needs. The slave base image includes all the jenkins logic to operate as a slave, so users just have to yum install any additional packages their specific jenkins job will need" \
-    io.openshift.tags="openshift,jenkins,slave" \
-    maintainer="openshift-dev-services+jenkins@redhat.com"
-
+    io.k8s.display-name="Jenkins Agent Base" \
+    io.k8s.description="The jenkins agent base image is intended to be built on top of, to add your own tools that your jenkins job needs. The slave base image includes all the jenkins logic to operate as a slave, so users just have to yum install any additional packages their specific jenkins job will need" \
+    maintainer="openshift-dev-services+jenkins@redhat.com" \
+    io.openshift.tags="openshift,jenkins,agent" \
+    License="GPLv2+" \
+    vendor="Red Hat, Inc." \
+    io.openshift.maintainer.product="OpenShift Container Platform" \
+    io.openshift.maintainer.component="Jenkins" \
+    io.openshift.build.commit.id="${CI_UPSTREAM_COMMIT}" \
+    io.openshift.build.source-location="${CI_UPSTREAM_URL}" \
+    io.openshift.build.commit.url="${CI_UPSTREAM_URL}/commit/${CI_UPSTREAM_COMMIT}" \
+    version="${OCP_VERSION}" \
+    url="https://catalog.redhat.com/software/containers/ocp-tools-4/jenkins-agent-base-rhel9/65dc9063b7db2e8b83a5b29e" \
+    summary="Provides a Jenkins agent base, primarily intended for integration with OpenShift v4" \
+    com.redhat.license_terms="https://www.redhat.com/agreements"
 
 ENV HOME=/home/jenkins \
     LANG=en_US.UTF-8 \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    BUILD_VERSION=${OCP_VERSION} \
+    OS_GIT_MINOR=${OS_GIT_MINOR} \
+    USE_JAVA_VERSION=java-21
 
 USER root
 # Install headless Java


### PR DESCRIPTION
**Summary**
Sync master branch with release-rhel9 to align Dockerfiles, verification scripts, and plugin install logic.

**Changes**

- Update slave-base base images and labels (slave -> agent, Konflux metadata)
- Switch verification scripts from rhel8 to rhel9 references
- Comment out RPM install commands for Konflux/cachi2 builds