### PR TITLE
JKNS-1063,JKNS-1061: Remove JDK 17 and Update Java to use JDK 25 by default

### DIFF
--- a/2/.konflux/Containerfile
+++ b/2/.konflux/Containerfile
@@ -55,16 +55,17 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-17-openjdk java-17-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-25-openjdk java-25-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    yum update -y chkconfig && \
     yum install -y $INSTALL_PKGS && \
     yum update -y && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --set javac $(alternatives --display javac | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --family $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
-    alternatives --set jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4)
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --set javac $(alternatives --display javac | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --family $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
+    alternatives --set jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4)
 
 COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin

--- a/2/Dockerfile.localdev
+++ b/2/Dockerfile.localdev
@@ -49,17 +49,18 @@ EXPOSE 8080 50000
 RUN rm /etc/yum.repos.d/*
 COPY contrib/openshift/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN curl http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS && \
-    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-17-openjdk java-17-openjdk-devel jq xmlstarlet" && \
+    INSTALL_PKGS="dejavu-sans-fonts rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-25-openjdk java-25-openjdk-devel jq xmlstarlet" && \
     DISABLES="" && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install epel-release && \
+    yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager update chkconfig && \
     yum $DISABLES -y --setopt=tsflags=nodocs --disableplugin=subscription-manager install $INSTALL_PKGS && \
     yum update --excludepkgs redhat-release -y && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --set javac $(alternatives --display javac | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --family $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
-    alternatives --set jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4)
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --set javac $(alternatives --display javac | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --family $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
+    alternatives --set jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4)
 
 COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin

--- a/2/Dockerfile.rhel8
+++ b/2/Dockerfile.rhel8
@@ -59,16 +59,17 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-17-openjdk java-17-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-25-openjdk java-25-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    yum update -y chkconfig && \
     yum install -y $INSTALL_PKGS && \
     yum update -y && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --set javac $(alternatives --display javac | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --family $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
-    alternatives --set jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4)
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --set javac $(alternatives --display javac | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --family $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
+    alternatives --set jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4)
 
 COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin

--- a/2/Dockerfile.rhel9
+++ b/2/Dockerfile.rhel9
@@ -47,7 +47,7 @@ ENV JENKINS_VERSION=2 \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     INSTALL_JENKINS_VIA_RPMS=${INSTALL_JENKINS_VIA_RPMS} \
-    USE_JAVA_VERSION=java-21 \
+    USE_JAVA_VERSION=java-25 \
     BUILD_VERSION=${OCP_VERSION} \
     OS_GIT_MINOR=${OS_GIT_MINOR}
 # openshift/ocp-build-data will change INSTALL_JENKINS_VIA_RPMS to true
@@ -88,16 +88,17 @@ EXPOSE 8080 50000
 # /usr/lib64/jenkins will subsequently get redirected to /usr/lib/jenkins; it is confirmed that the 3.7 jenkins RHEL images
 # do *NOT* have a /usr/lib64/jenkins path
 RUN ln -s /usr/lib/jenkins /usr/lib64/jenkins && \
-    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-17-openjdk java-17-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    INSTALL_PKGS="dejavu-sans-fonts wget rsync gettext git git-lfs tar zip unzip openssl bzip2 java-21-openjdk java-21-openjdk-devel java-25-openjdk java-25-openjdk-devel jq glibc-locale-source xmlstarlet glibc-langpack-en" && \
+    yum update -y chkconfig && \
     yum install -y $INSTALL_PKGS && \
     yum update -y && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all  && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --set javac $(alternatives --display javac | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
-    alternatives --family $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
-    alternatives --set jar $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 4)
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --set javac $(alternatives --display javac | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
+    alternatives --family $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4) --install /usr/bin/jar  jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d' ' -f1 | sed 's,/[^/]*$,/jar,') 1 && \
+    alternatives --set jar $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 4)
 
 COPY ./contrib/openshift /opt/openshift
 COPY ./contrib/jenkins /usr/local/bin

--- a/2/contrib/s2i/run
+++ b/2/contrib/s2i/run
@@ -293,15 +293,9 @@ function container_max_memory_bytes() {
 CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
-export JAVA_VERSION=${USE_JAVA_VERSION:=java-21}
-if [[ "$(uname -m)" == "x86_64" ]]; then
-	alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
-	alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
-#set JVM for all other archs
-else
-  alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
-  alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
-fi
+export JAVA_VERSION=${USE_JAVA_VERSION:=java-25}
+alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/priority/ { print $1; }')
+alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/priority/ { print $1; }')
 
 echo "CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java) and $(readlink /etc/alternatives/javac)"
 

--- a/openshift/templates/jenkins-ephemeral-monitored.json
+++ b/openshift/templates/jenkins-ephemeral-monitored.json
@@ -355,7 +355,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/configuring_red_hat_build_of_openjdk_21_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-ephemeral.json
+++ b/openshift/templates/jenkins-ephemeral.json
@@ -323,7 +323,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/configuring_red_hat_build_of_openjdk_21_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-persistent-monitored.json
+++ b/openshift/templates/jenkins-persistent-monitored.json
@@ -383,7 +383,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/configuring_red_hat_build_of_openjdk_21_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/openshift/templates/jenkins-persistent.json
+++ b/openshift/templates/jenkins-persistent.json
@@ -351,7 +351,7 @@
     {
       "name": "JAVA_FIPS_OPTIONS",
       "displayName": "Allows control over how the JVM interacts with FIPS on startup.",
-      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/17/html-single/configuring_red_hat_build_of_openjdk_17_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
+      "description": "See https://docs.redhat.com/en/documentation/red_hat_build_of_openjdk/21/html-single/configuring_red_hat_build_of_openjdk_21_on_rhel_with_fips/index#fips_settings for the available command line properties to facilitate the JVM running on FIPS nodes.",
       "value": "-Dcom.redhat.fips=false"
     },
     {

--- a/scripts/verify-jenkins.sh
+++ b/scripts/verify-jenkins.sh
@@ -156,7 +156,7 @@ verify_plugins() {
 verify_jenkins_war() {
 	jenkins_version=$(cat "$COMMIT_JENKINS_VERSION_LOCATION")
 	printf "[VERIFYING] %s:%s\n" "$JENKINS_WAR_LOCATION" "${jenkins_version}"
-	jenkins_version_found=$(/usr/lib/jvm/java-21/bin/java -jar "$JENKINS_WAR_LOCATION" --version 2> /dev/null)
+	jenkins_version_found=$(/usr/lib/jvm/java-25/bin/java -jar "$JENKINS_WAR_LOCATION" --version 2> /dev/null)
 	printf "\t%-50s" "- exists ... "
 		if test -f "$JENKINS_WAR_LOCATION"; then
 			printf "PASS\n"

--- a/slave-base/Dockerfile.localdev
+++ b/slave-base/Dockerfile.localdev
@@ -22,13 +22,14 @@ USER root
 # Install headless Java
 COPY contrib/openshift/CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
 RUN curl http://mirror.centos.org/centos-7/7/os/x86_64/RPM-GPG-KEY-CentOS-7 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    INSTALL_PKGS="bc gettext git git-lfs java-21-openjdk-headless java-17-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
+    INSTALL_PKGS="bc gettext git git-lfs java-21-openjdk-headless java-25-openjdk-headless lsof rsync tar unzip which zip bzip2 jq" && \
     DISABLES="--disablerepo=rhel-server-extras --disablerepo=rhel-server --disablerepo=rhel-fast-datapath --disablerepo=rhel-server-optional --disablerepo=rhel-server-ose --disablerepo=rhel-server-rhscl" && \
     yum $DISABLES install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager epel-release && \
+    yum $DISABLES update -y chkconfig && \
     yum $DISABLES install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum clean all && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \

--- a/slave-base/Dockerfile.rhel8
+++ b/slave-base/Dockerfile.rhel8
@@ -29,13 +29,14 @@ ENV HOME=/home/jenkins \
 
 USER root
 # Install headless Java
-RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-21-openjdk-headless java-17-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
+RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-21-openjdk-headless java-25-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
+    yum update -y chkconfig && \
     yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum update -y && \
     yum clean all && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \

--- a/slave-base/Dockerfile.rhel9
+++ b/slave-base/Dockerfile.rhel9
@@ -29,13 +29,14 @@ ENV HOME=/home/jenkins \
 
 USER root
 # Install headless Java
-RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-21-openjdk-headless java-17-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
+RUN INSTALL_PKGS="glibc-langpack-en bc gettext git git-lfs java-21-openjdk-headless java-25-openjdk-headless lsof rsync tar unzip which zip bzip2 jq glibc-locale-source" && \
+    yum update -y chkconfig && \
     yum install -y --setopt=tsflags=nodocs --disableplugin=subscription-manager $INSTALL_PKGS && \
     rpm -V  $INSTALL_PKGS && \
     yum update -y && \
     yum clean all && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \
-    alternatives --set java $(alternatives --display java | grep 'family java-21-openjdk' | cut -d ' ' -f 1) && \
+    alternatives --set java $(alternatives --display java | grep 'java-25-openjdk.*priority' | cut -d ' ' -f 1) && \
     mkdir -p /home/jenkins && \
     chown -R 1001:0 /home/jenkins && \
     chmod -R g+w /home/jenkins && \

--- a/slave-base/contrib/bin/run-jnlp-client
+++ b/slave-base/contrib/bin/run-jnlp-client
@@ -13,7 +13,7 @@ export JENKINS_HOME=/home/jenkins
 # Make sure the Java clients have valid $HOME directory set
 export HOME=${JENKINS_HOME}
 
-export JAVA_VERSION=${USE_JAVA_VERSION:=java-21}
+export JAVA_VERSION=${USE_JAVA_VERSION:=java-25}
 
 function linux_available_memory_bytes() {
   local kbytes
@@ -44,14 +44,8 @@ function container_max_memory_bytes() {
 CONTAINER_MEMORY_IN_BYTES=$(container_max_memory_bytes)
 CONTAINER_MEMORY_IN_MB=$((CONTAINER_MEMORY_IN_BYTES/2**20))
 
-if [[ "$(uname -m)" == "x86_64" ]]; then
-	alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
-	alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*x86_64/ { print $1; }')
-#set JVM for all other archs
-else
-  alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
-  alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/family.*'$(uname -m)'/ { print $1; }')
-fi
+alternatives --set java $(alternatives --display java | grep $JAVA_VERSION | awk '/priority/ { print $1; }')
+alternatives --set javac $(alternatives --display javac | grep $JAVA_VERSION | awk '/priority/ { print $1; }')
 
 echo "OPENSHIFT_JENKINS_JVM_ARCH='${OPENSHIFT_JENKINS_JVM_ARCH}', CONTAINER_MEMORY_IN_MB='${CONTAINER_MEMORY_IN_MB}', using $(readlink /etc/alternatives/java)"
 


### PR DESCRIPTION
Changes:
- Remove JDK 17 as it has reached End Of Life
- Update JDK version to 25 in builder images and all other references
- Use JDK 25 as default