### PR TITLE
JKNS-1080: Fix Jenkins RPM repo path for CI

### DIFF
--- a/2/contrib/jenkins/install-jenkins-core-plugins.sh
+++ b/2/contrib/jenkins/install-jenkins-core-plugins.sh
@@ -18,7 +18,8 @@ if [[ "${INSTALL_JENKINS_VIA_RPMS}" == false ]]; then
         echo "jenkins.war already exists, skipping upstream RPM installation"
     else
         echo "Installing jenkins.war from upstream RPM"
-        curl https://pkg.jenkins.io/rpm-stable/jenkins.repo -o /etc/yum.repos.d/jenkins.repo
+        mkdir -p /etc/yum.repos.art/ci
+        curl https://pkg.jenkins.io/rpm-stable/jenkins.repo | tee /etc/yum.repos.d/jenkins.repo /etc/yum.repos.art/ci/jenkins.repo
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins-ci.org.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io.key
         rpm --import https://pkg.jenkins.io/redhat-stable/jenkins.io-2023.key


### PR DESCRIPTION
The ART dnf wrapper in OCP 4.19+ changed to only read repo files from /etc/yum.repos.art/ci/ using --setopt=reposdir, ignoring /etc/yum.repos.d/ entirely. 
Write the Jenkins repo file to both paths to support CI and local builds.