### PR TITLE
JKNS-1091: Forward LABELS param to build-images task in build pipeline (release-rhel8)

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -62,6 +62,10 @@ spec:
       description: Array of --build-arg values ("arg=value" strings) for buildah
       name: build-args
       type: array
+    - default: []
+      description: Additional key=value labels that should be applied to the image
+      name: LABELS
+      type: array
     - default: ""
       description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
       name: build-args-file
@@ -188,6 +192,9 @@ spec:
             - $(params.build-args[*])
         - name: BUILD_ARGS_FILE
           value: $(params.build-args-file)
+        - name: LABELS
+          value:
+            - $(params.LABELS[*])
         - name: PRIVILEGED_NESTED
           value: $(params.privileged-nested)
         - name: SOURCE_URL


### PR DESCRIPTION
## Summary
- Forward the `LABELS` pipeline parameter to the `build-images` task (`buildah-remote-oci-ta`) in `build-pipeline.yaml`
- The `LABELS` param was already specified in PipelineRun files but silently ignored because the pipeline never declared or passed it through
- This fix ensures labels like `cpe` and `io.openshift.release.version` are properly applied to built images per [Konflux documentation](https://konflux-ci.dev/docs/building/labels-and-annotations/)

## Problem
Built images inherit `cpe` from the base image (`ose-cli-rhel8:v4.16`) instead of getting the correct per-version value (e.g. `cpe:/a:redhat:openshift:4.12::el8`).

## Changes
- Declare `LABELS` as a pipeline parameter (defaults to `[]`)
- Forward `$(params.LABELS[*])` to the `build-images` task

## Test plan
- [ ] Verify the Tekton pipeline YAML is valid
- [ ] After merge, inspect built images with `skopeo inspect` to confirm `cpe` and `io.openshift.release.version` labels are applied correctly

Made with [Cursor](https://cursor.com)