### PR TITLE
JKNS-1088: Update CPE labels from openshift to ocp_tools in Tekton pi…

### DIFF
--- a/.tekton/jenkins-agent-base-rhel8-4-12-pull-request.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-12-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.12"
         - "version=4.12"
-        - "cpe=cpe:/a:redhat:openshift:4.12::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.12::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-12
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-12-push.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-12-push.yaml
@@ -48,7 +48,7 @@ spec:
       value:
         - "io.openshift.release.version=4.12"
         - "version=4.12"
-        - "cpe=cpe:/a:redhat:openshift:4.12::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.12::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-12
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-13-pull-request.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-13-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.13"
         - "version=4.13"
-        - "cpe=cpe:/a:redhat:openshift:4.13::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.13::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-13
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-13-push.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-13-push.yaml
@@ -48,7 +48,7 @@ spec:
       value:
         - "io.openshift.release.version=4.13"
         - "version=4.13"
-        - "cpe=cpe:/a:redhat:openshift:4.13::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.13::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-13
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-14-pull-request.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-14-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.14"
         - "version=4.14"
-        - "cpe=cpe:/a:redhat:openshift:4.14::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.14::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-14
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-14-push.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-14-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.14"
         - "version=4.14"
-        - "cpe=cpe:/a:redhat:openshift:4.14::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.14::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-14
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-15-pull-request.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-15-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.15"
         - "version=4.15"
-        - "cpe=cpe:/a:redhat:openshift:4.15::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.15::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-15
   workspaces:

--- a/.tekton/jenkins-agent-base-rhel8-4-15-push.yaml
+++ b/.tekton/jenkins-agent-base-rhel8-4-15-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.15"
         - "version=4.15"
-        - "cpe=cpe:/a:redhat:openshift:4.15::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.15::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-agent-base-rhel8-4-15
   workspaces:

--- a/.tekton/jenkins-rhel8-4-12-pull-request.yaml
+++ b/.tekton/jenkins-rhel8-4-12-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.12"
         - "version=4.12"
-        - "cpe=cpe:/a:redhat:openshift:4.12::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.12::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-12
   workspaces:

--- a/.tekton/jenkins-rhel8-4-12-push.yaml
+++ b/.tekton/jenkins-rhel8-4-12-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.12"
         - "version=4.12"
-        - "cpe=cpe:/a:redhat:openshift:4.12::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.12::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-12
   workspaces:

--- a/.tekton/jenkins-rhel8-4-13-pull-request.yaml
+++ b/.tekton/jenkins-rhel8-4-13-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.13"
         - "version=4.13"
-        - "cpe=cpe:/a:redhat:openshift:4.13::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.13::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-13
   workspaces:

--- a/.tekton/jenkins-rhel8-4-13-push.yaml
+++ b/.tekton/jenkins-rhel8-4-13-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.13"
         - "version=4.13"
-        - "cpe=cpe:/a:redhat:openshift:4.13::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.13::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-13
   workspaces:

--- a/.tekton/jenkins-rhel8-4-14-pull-request.yaml
+++ b/.tekton/jenkins-rhel8-4-14-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.14"
         - "version=4.14"
-        - "cpe=cpe:/a:redhat:openshift:4.14::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.14::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-14
   workspaces:

--- a/.tekton/jenkins-rhel8-4-14-push.yaml
+++ b/.tekton/jenkins-rhel8-4-14-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.14"
         - "version=4.14"
-        - "cpe=cpe:/a:redhat:openshift:4.14::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.14::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-14
   workspaces:

--- a/.tekton/jenkins-rhel8-4-15-pull-request.yaml
+++ b/.tekton/jenkins-rhel8-4-15-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
       value:
         - "io.openshift.release.version=4.15"
         - "version=4.15"
-        - "cpe=cpe:/a:redhat:openshift:4.15::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.15::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-15
   workspaces:

--- a/.tekton/jenkins-rhel8-4-15-push.yaml
+++ b/.tekton/jenkins-rhel8-4-15-push.yaml
@@ -51,7 +51,7 @@ spec:
       value:
         - "io.openshift.release.version=4.15"
         - "version=4.15"
-        - "cpe=cpe:/a:redhat:openshift:4.15::el8"
+        - "cpe=cpe:/a:redhat:ocp_tools:4.15::el8"
   taskRunTemplate:
     serviceAccountName: build-pipeline-jenkins-rhel8-4-15
   workspaces:


### PR DESCRIPTION
…pelines

The CPE product identifier for these builds should reflect that they are OCP tools components rather than the OpenShift platform itself.

Updates all .tekton/ pipeline definitions (jenkins-rhel8 and jenkins-agent-base-rhel8, versions 4.12-4.15) to use cpe:/a:redhat:ocp_tools instead of cpe:/a:redhat:openshift.